### PR TITLE
Allow committing a degree-zero polynomial (aka constant)

### DIFF
--- a/src/ipa_pc/mod.rs
+++ b/src/ipa_pc/mod.rs
@@ -188,9 +188,7 @@ impl<G: AffineCurve, D: Digest, P: UVPolynomial<G::ScalarField>> InnerProductArg
         supported_degree: usize,
         p: &LabeledPolynomial<G::ScalarField, P>,
     ) -> Result<(), Error> {
-        if p.degree() < 1 {
-            return Err(Error::DegreeIsZero);
-        } else if p.degree() > supported_degree {
+        if p.degree() > supported_degree {
             return Err(Error::TooManyCoefficients {
                 num_coefficients: p.degree() + 1,
                 num_powers: supported_degree + 1,
@@ -1051,6 +1049,14 @@ mod tests {
         DensePoly::rand(degree, rng)
     }
 
+    fn constant_poly<F: PrimeField>(
+        _: usize,
+        _: Option<usize>,
+        rng: &mut rand::prelude::StdRng,
+    ) -> DensePoly<F> {
+        DensePoly::from_coefficients_slice(&[F::rand(rng)])
+    }
+
     fn rand_point<F: PrimeField>(_: Option<usize>, rng: &mut rand::prelude::StdRng) -> F {
         F::rand(rng)
     }
@@ -1059,6 +1065,13 @@ mod tests {
     fn single_poly_test() {
         use crate::tests::*;
         single_poly_test::<_, _, PC_JJB2S>(None, rand_poly::<Fr>, rand_point::<Fr>)
+            .expect("test failed for ed_on_bls12_381-blake2s");
+    }
+
+    #[test]
+    fn constant_poly_test() {
+        use crate::tests::*;
+        single_poly_test::<_, _, PC_JJB2S>(None, constant_poly::<Fr>, rand_point::<Fr>)
             .expect("test failed for ed_on_bls12_381-blake2s");
     }
 

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -149,7 +149,7 @@ where
         hiding_bound: Option<usize>,
         rng: Option<&mut dyn RngCore>,
     ) -> Result<(Commitment<E>, Randomness<E::Fr, P>), Error> {
-        Self::check_degree_is_within_bounds(polynomial.degree(), powers.size())?;
+        Self::check_degree_is_too_large(polynomial.degree(), powers.size())?;
 
         let commit_time = start_timer!(|| format!(
             "Committing to polynomial of degree {} with hiding_bound: {:?}",
@@ -276,7 +276,7 @@ where
         point: P::Point,
         rand: &Randomness<E::Fr, P>,
     ) -> Result<Proof<E>, Error> {
-        Self::check_degree_is_within_bounds(p.degree(), powers.size())?;
+        Self::check_degree_is_too_large(p.degree(), powers.size())?;
         let open_time = start_timer!(|| format!("Opening polynomial of degree {}", p.degree()));
 
         let witness_time = start_timer!(|| "Computing witness polynomials");
@@ -377,18 +377,6 @@ where
         Ok(result)
     }
 
-    // Functions for checking errors
-    pub(crate) fn check_degree_is_within_bounds(
-        num_coefficients: usize,
-        num_powers: usize,
-    ) -> Result<(), Error> {
-        if num_coefficients < 1 {
-            Err(Error::DegreeIsZero)
-        } else {
-            Self::check_degree_is_too_large(num_coefficients, num_powers)
-        }
-    }
-
     pub(crate) fn check_degree_is_too_large(
         num_coefficients: usize,
         num_powers: usize,
@@ -454,7 +442,7 @@ fn skip_leading_zeros_and_convert_to_bigints<F: PrimeField, P: UVPolynomial<F>>(
     p: &P,
 ) -> (usize, Vec<F::BigInt>) {
     let mut num_leading_zeros = 0;
-    while p.coeffs()[num_leading_zeros].is_zero() && num_leading_zeros < p.coeffs().len() {
+    while num_leading_zeros < p.coeffs().len() && p.coeffs()[num_leading_zeros].is_zero() {
         num_leading_zeros += 1;
     }
     let coeffs = convert_to_bigints(&p.coeffs()[num_leading_zeros..]);

--- a/src/marlin_pc/mod.rs
+++ b/src/marlin_pc/mod.rs
@@ -840,6 +840,14 @@ mod tests {
         DensePoly::<E::Fr>::rand(degree, rng)
     }
 
+    fn constant_poly<E: PairingEngine>(
+        _: usize,
+        _: Option<usize>,
+        rng: &mut rand::prelude::StdRng,
+    ) -> DensePoly<E::Fr> {
+        DensePoly::<E::Fr>::from_coefficients_slice(&[E::Fr::rand(rng)])
+    }
+
     fn rand_point<E: PairingEngine>(_: Option<usize>, rng: &mut rand::prelude::StdRng) -> E::Fr {
         E::Fr::rand(rng)
     }
@@ -856,6 +864,23 @@ mod tests {
         single_poly_test::<_, _, PC_Bls12_381>(
             None,
             rand_poly::<Bls12_381>,
+            rand_point::<Bls12_381>,
+        )
+        .expect("test failed for bls12-381");
+    }
+
+    #[test]
+    fn constant_poly_test() {
+        use crate::tests::*;
+        single_poly_test::<_, _, PC_Bls12_377>(
+            None,
+            constant_poly::<Bls12_377>,
+            rand_point::<Bls12_377>,
+        )
+        .expect("test failed for bls12-377");
+        single_poly_test::<_, _, PC_Bls12_381>(
+            None,
+            constant_poly::<Bls12_381>,
             rand_point::<Bls12_381>,
         )
         .expect("test failed for bls12-381");


### PR DESCRIPTION
Currently, the library disables committing a polynomial of degree zero. This requirement seems unnecessary because:
- Both related papers for KZG and IPA did not say a degree-zero polynomial cannot be committed in their schemes.

Allowing this would have certain benefits. 

For example, sometimes we may use a dummy circuit, which may be so dummy that its arithmetization has a degree of zero. Currently, these checks prohibit such dummy circuits. But for completeness, they should be permitted.

Tests for such zero-degree polynomials are also added.

This PR closes https://github.com/arkworks-rs/poly-commit/issues/40.