### PR TITLE
Add traits for constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ ark-ec = { git = "https://github.com/arkworks-rs/algebra", default-features = fa
 ark-poly = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
 
 ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
+ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features = false, optional = true }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-features = false, optional = true }
+ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false, optional = true }
+hashbrown = { version = "0.9", optional = true }
 
 bench-utils = { git = "https://github.com/arkworks-rs/utils", default-features = false  }
 
@@ -57,5 +61,6 @@ debug = true
 [features]
 default = [ "std", "parallel" ]
 std = [ "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", "ark-serialize/std" ]
+r1cs = [ "ark-relations", "ark-r1cs-std", "ark-nonnative-field", "hashbrown" ]
 print-trace = [ "bench-utils/print-trace" ]
 parallel = [ "std", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "ark-std/parallel", "rayon" ]

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -1,0 +1,205 @@
+use crate::{
+    data_structures::LabeledCommitment, BatchLCProof, LCTerm, LinearCombination,
+    PolynomialCommitment, String, Vec,
+};
+use ark_ff::PrimeField;
+use ark_nonnative_field::NonNativeFieldVar;
+use ark_poly::Polynomial;
+use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
+use ark_relations::r1cs::{ConstraintSystemRef, Namespace, Result as R1CSResult, SynthesisError};
+use ark_std::{borrow::Borrow, cmp::Eq, cmp::PartialEq, hash::Hash, marker::Sized};
+use hashbrown::{HashMap, HashSet};
+
+/// Define the minimal interface of prepared allocated structures.
+pub trait PreparedVar<Unprepared, ConstraintF: PrimeField>: Sized {
+    /// Prepare from an unprepared element.
+    fn prepare(unprepared: &Unprepared) -> R1CSResult<Self>;
+}
+
+/// A coefficient of `LinearCombination`.
+#[allow(non_camel_case_types)]
+pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeField> {
+    /// Coefficient 1.
+    ONE,
+    /// Coefficient -1.
+    MINUS_ONE,
+    /// Other coefficient, represented as a nonnative field element.
+    Var(NonNativeFieldVar<TargetField, BaseField>),
+}
+
+impl<TargetField: PrimeField, BaseField: PrimeField> From<NonNativeFieldVar<TargetField, BaseField>>
+    for LinearCombinationCoeffVar<TargetField, BaseField>
+{
+    fn from(v: NonNativeFieldVar<TargetField, BaseField>) -> Self {
+        Self::Var(v)
+    }
+}
+
+/// An allocated version of `LinearCombination`.
+#[derive(Clone)]
+pub struct LinearCombinationVar<TargetField: PrimeField, BaseField: PrimeField> {
+    /// The label.
+    pub label: String,
+    /// The linear combination of `(coeff, poly_label)` pairs.
+    pub terms: Vec<(Option<NonNativeFieldVar<TargetField, BaseField>>, LCTerm)>,
+}
+
+impl<TargetField: PrimeField, BaseField: PrimeField>
+    AllocVar<LinearCombination<TargetField>, BaseField>
+    for LinearCombinationVar<TargetField, BaseField>
+{
+    fn new_variable<T>(
+        cs: impl Into<Namespace<BaseField>>,
+        val: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> R1CSResult<Self>
+    where
+        T: Borrow<LinearCombination<TargetField>>,
+    {
+        let LinearCombination { label, terms } = val()?.borrow().clone();
+
+        let ns = cs.into();
+        let cs = ns.cs();
+
+        let new_terms: Vec<(Option<NonNativeFieldVar<TargetField, BaseField>>, LCTerm)> = terms
+            .iter()
+            .map(|term| {
+                let (f, lc_term) = term;
+
+                let fg =
+                    NonNativeFieldVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
+                        .unwrap();
+
+                (Some(fg), lc_term.clone())
+            })
+            .collect();
+
+        Ok(Self {
+            label,
+            terms: new_terms,
+        })
+    }
+}
+
+#[derive(Clone)]
+/// A collection of random data used in the polynomial commitment checking.
+pub struct PCCheckRandomDataVar<TargetField: PrimeField, BaseField: PrimeField> {
+    /// Opening challenges.
+    /// The prover and the verifier MUST use the same opening challenges.
+    pub opening_challenges: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    /// Bit representations of the opening challenges.
+    pub opening_challenges_bits: Vec<Vec<Boolean<BaseField>>>,
+    /// Batching random numbers.
+    /// The verifier can choose these numbers freely, as long as they are random.
+    pub batching_rands: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    /// Bit representations of the batching random numbers.
+    pub batching_rands_bits: Vec<Vec<Boolean<BaseField>>>,
+}
+
+/// Describes the interface for a gadget for a `PolynomialCommitment`
+/// verifier.
+pub trait PCCheckVar<
+    PCF: PrimeField,
+    P: Polynomial<PCF>,
+    PC: PolynomialCommitment<PCF, P>,
+    ConstraintF: PrimeField,
+>: Clone
+{
+    /// An allocated version of `PC::VerifierKey`.
+    type VerifierKeyVar: AllocVar<PC::VerifierKey, ConstraintF> + Clone + ToBytesGadget<ConstraintF>;
+    /// An allocated version of `PC::PreparedVerifierKey`.
+    type PreparedVerifierKeyVar: AllocVar<PC::PreparedVerifierKey, ConstraintF>
+        + Clone
+        + PreparedVar<Self::VerifierKeyVar, ConstraintF>;
+    /// An allocated version of `PC::Commitment`.
+    type CommitmentVar: AllocVar<PC::Commitment, ConstraintF> + Clone + ToBytesGadget<ConstraintF>;
+    /// An allocated version of `PC::PreparedCommitment`.
+    type PreparedCommitmentVar: AllocVar<PC::PreparedCommitment, ConstraintF>
+        + PreparedVar<Self::CommitmentVar, ConstraintF>
+        + Clone;
+    /// An allocated version of `LabeledCommitment<PC::Commitment>`.
+    type LabeledCommitmentVar: AllocVar<LabeledCommitment<PC::Commitment>, ConstraintF> + Clone;
+    /// A prepared, allocated version of `LabeledCommitment<PC::Commitment>`.
+    type PreparedLabeledCommitmentVar: Clone;
+    /// An allocated version of `PC::Proof`.
+    type ProofVar: AllocVar<PC::Proof, ConstraintF> + Clone;
+
+    /// An allocated version of `PC::BatchLCProof`.
+    type BatchLCProofVar: AllocVar<BatchLCProof<PCF, P, PC>, ConstraintF> + Clone;
+
+    /// Add to `ConstraintSystemRef<ConstraintF>` new constraints that check that `proof_i` is a valid evaluation
+    /// proof at `point_i` for the polynomial in `commitment_i`.
+    fn batch_check_evaluations(
+        cs: ConstraintSystemRef<ConstraintF>,
+        verification_key: &Self::VerifierKeyVar,
+        commitments: &[Self::LabeledCommitmentVar],
+        query_set: &QuerySetVar<PCF, ConstraintF>,
+        evaluations: &EvaluationsVar<PCF, ConstraintF>,
+        proofs: &[Self::ProofVar],
+        rand_data: &PCCheckRandomDataVar<PCF, ConstraintF>,
+    ) -> R1CSResult<Boolean<ConstraintF>>;
+
+    /// Add to `ConstraintSystemRef<ConstraintF>` new constraints that conditionally check that `proof` is a valid evaluation
+    /// proof at the points in `query_set` for the combinations `linear_combinations`.
+    fn prepared_check_combinations(
+        cs: ConstraintSystemRef<ConstraintF>,
+        prepared_verification_key: &Self::PreparedVerifierKeyVar,
+        linear_combinations: &[LinearCombinationVar<PCF, ConstraintF>],
+        prepared_commitments: &[Self::PreparedLabeledCommitmentVar],
+        query_set: &QuerySetVar<PCF, ConstraintF>,
+        evaluations: &EvaluationsVar<PCF, ConstraintF>,
+        proof: &Self::BatchLCProofVar,
+        rand_data: &PCCheckRandomDataVar<PCF, ConstraintF>,
+    ) -> R1CSResult<Boolean<ConstraintF>>;
+
+    /// Create the labeled commitment gadget from the commitment gadget
+    fn create_labeled_commitment_gadget(
+        label: String,
+        commitment: Self::CommitmentVar,
+        degree_bound: Option<FpVar<ConstraintF>>,
+    ) -> Self::LabeledCommitmentVar;
+
+    /// Create the prepared labeled commitment gadget from the commitment gadget
+    fn create_prepared_labeled_commitment_gadget(
+        label: String,
+        commitment: Self::PreparedCommitmentVar,
+        degree_bound: Option<FpVar<ConstraintF>>,
+    ) -> Self::PreparedLabeledCommitmentVar;
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
+/// A labeled point variable, for queries to a polynomial commitment.
+pub struct LabeledPointVar<TargetField: PrimeField, BaseField: PrimeField> {
+    /// The label of the point.
+    /// MUST be a unique identifier in a query set.
+    pub name: String,
+    /// The point value.
+    pub value: NonNativeFieldVar<TargetField, BaseField>,
+}
+
+/// An allocated version of `QuerySet`.
+#[derive(Clone)]
+pub struct QuerySetVar<TargetField: PrimeField, BaseField: PrimeField>(
+    pub HashSet<(String, LabeledPointVar<TargetField, BaseField>)>,
+);
+
+/// An allocated version of `Evaluations`.
+#[derive(Clone)]
+pub struct EvaluationsVar<TargetField: PrimeField, BaseField: PrimeField>(
+    pub HashMap<LabeledPointVar<TargetField, BaseField>, NonNativeFieldVar<TargetField, BaseField>>,
+);
+
+impl<TargetField: PrimeField, BaseField: PrimeField> EvaluationsVar<TargetField, BaseField> {
+    /// find the evaluation result
+    pub fn get_lc_eval(
+        &self,
+        lc_string: &str,
+        point: &NonNativeFieldVar<TargetField, BaseField>,
+    ) -> Result<NonNativeFieldVar<TargetField, BaseField>, SynthesisError> {
+        let key = LabeledPointVar::<TargetField, BaseField> {
+            name: String::from(lc_string),
+            value: point.clone(),
+        };
+        Ok(self.0.get(&key).map(|v| (*v).clone()).unwrap())
+    }
+}

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -11,7 +11,7 @@ use ark_std::{borrow::Borrow, cmp::Eq, cmp::PartialEq, hash::Hash, marker::Sized
 use hashbrown::{HashMap, HashSet};
 
 /// Define the minimal interface of prepared allocated structures.
-pub trait PreparedVar<Unprepared, ConstraintF: PrimeField>: Sized {
+pub trait PrepareGadget<Unprepared, ConstraintF: PrimeField>: Sized {
     /// Prepare from an unprepared element.
     fn prepare(unprepared: &Unprepared) -> R1CSResult<Self>;
 }

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -146,14 +146,14 @@ pub trait PCCheckVar<
     ) -> R1CSResult<Boolean<ConstraintF>>;
 
     /// Create the labeled commitment gadget from the commitment gadget
-    fn create_labeled_commitment_var(
+    fn create_labeled_commitment(
         label: String,
         commitment: Self::CommitmentVar,
         degree_bound: Option<FpVar<ConstraintF>>,
     ) -> Self::LabeledCommitmentVar;
 
     /// Create the prepared labeled commitment gadget from the commitment gadget
-    fn create_prepared_labeled_commitment_var(
+    fn create_prepared_labeled_commitment(
         label: String,
         commitment: Self::PreparedCommitmentVar,
         degree_bound: Option<FpVar<ConstraintF>>,

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -153,7 +153,7 @@ pub trait PCCheckVar<
     ) -> Self::LabeledCommitmentVar;
 
     /// Create the prepared labeled commitment gadget from the commitment gadget
-    fn create_prepared_labeled_commitment_gadget(
+    fn create_prepared_labeled_commitment_var(
         label: String,
         commitment: Self::PreparedCommitmentVar,
         degree_bound: Option<FpVar<ConstraintF>>,

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -21,9 +21,9 @@ pub trait PreparedVar<Unprepared, ConstraintF: PrimeField>: Sized {
 #[derive(Clone)]
 pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Coefficient 1.
-    ONE,
+    One,
     /// Coefficient -1.
-    MINUS_ONE,
+    MinusOne,
     /// Other coefficient, represented as a nonnative field element.
     Var(NonNativeFieldVar<TargetField, BaseField>),
 }

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -103,12 +103,12 @@ pub trait PCCheckVar<
     /// An allocated version of `PC::PreparedVerifierKey`.
     type PreparedVerifierKeyVar: AllocVar<PC::PreparedVerifierKey, ConstraintF>
         + Clone
-        + PreparedVar<Self::VerifierKeyVar, ConstraintF>;
+        + PrepareGadget<Self::VerifierKeyVar, ConstraintF>;
     /// An allocated version of `PC::Commitment`.
     type CommitmentVar: AllocVar<PC::Commitment, ConstraintF> + Clone + ToBytesGadget<ConstraintF>;
     /// An allocated version of `PC::PreparedCommitment`.
     type PreparedCommitmentVar: AllocVar<PC::PreparedCommitment, ConstraintF>
-        + PreparedVar<Self::CommitmentVar, ConstraintF>
+        + PrepareGadget<Self::CommitmentVar, ConstraintF>
         + Clone;
     /// An allocated version of `LabeledCommitment<PC::Commitment>`.
     type LabeledCommitmentVar: AllocVar<LabeledCommitment<PC::Commitment>, ConstraintF> + Clone;

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -18,6 +18,7 @@ pub trait PreparedVar<Unprepared, ConstraintF: PrimeField>: Sized {
 
 /// A coefficient of `LinearCombination`.
 #[allow(non_camel_case_types)]
+#[derive(Clone)]
 pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Coefficient 1.
     ONE,
@@ -27,21 +28,13 @@ pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeFiel
     Var(NonNativeFieldVar<TargetField, BaseField>),
 }
 
-impl<TargetField: PrimeField, BaseField: PrimeField> From<NonNativeFieldVar<TargetField, BaseField>>
-    for LinearCombinationCoeffVar<TargetField, BaseField>
-{
-    fn from(v: NonNativeFieldVar<TargetField, BaseField>) -> Self {
-        Self::Var(v)
-    }
-}
-
 /// An allocated version of `LinearCombination`.
 #[derive(Clone)]
 pub struct LinearCombinationVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// The label.
     pub label: String,
     /// The linear combination of `(coeff, poly_label)` pairs.
-    pub terms: Vec<(Option<NonNativeFieldVar<TargetField, BaseField>>, LCTerm)>,
+    pub terms: Vec<(LinearCombinationCoeffVar<TargetField, BaseField>, LCTerm)>,
 }
 
 impl<TargetField: PrimeField, BaseField: PrimeField>
@@ -61,7 +54,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
         let ns = cs.into();
         let cs = ns.cs();
 
-        let new_terms: Vec<(Option<NonNativeFieldVar<TargetField, BaseField>>, LCTerm)> = terms
+        let new_terms: Vec<(LinearCombinationCoeffVar<TargetField, BaseField>, LCTerm)> = terms
             .iter()
             .map(|term| {
                 let (f, lc_term) = term;
@@ -70,7 +63,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
                     NonNativeFieldVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
                         .unwrap();
 
-                (Some(fg), lc_term.clone())
+                (LinearCombinationCoeffVar::Var(fg), lc_term.clone())
             })
             .collect();
 

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -146,7 +146,7 @@ pub trait PCCheckVar<
     ) -> R1CSResult<Boolean<ConstraintF>>;
 
     /// Create the labeled commitment gadget from the commitment gadget
-    fn create_labeled_commitment_gadget(
+    fn create_labeled_commitment_var(
         label: String,
         commitment: Self::CommitmentVar,
         degree_bound: Option<FpVar<ConstraintF>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,12 @@ use ark_std::{
 pub mod data_structures;
 pub use data_structures::*;
 
+/// R1CS constraints for polynomial constraints.
+#[cfg(feature = "r1cs")]
+mod constraints;
+#[cfg(feature = "r1cs")]
+pub use constraints::*;
+
 /// Errors pertaining to query sets.
 pub mod error;
 pub use error::*;


### PR DESCRIPTION
This is a tidy-up version of the trait sub-component (`src/constraints.rs`) of the constraints PR (#47). 

I did a few changes:
- `PreparedVar` no longer has `prepare_small` since it is no longer very useful in the new Marlin PC check.
- Let the `terms` in `LinearCombinationVar` make more sense by separating the coefficient part out as a struct `LinearCombinationCoeffVar`, which is more sensible.
- Reduce the number of arguments to several functions in the `PCCheckVar` by separating `opening_callenges (_bits)` and `batching_rands(_bits)` into a separate struct `PCCheckRandomDataVar`.

Question:

- Should `PreparedVar` be `PrepareGadget`?

This PR is not automatically compatible with the `constraints` branch. Some small refactoring to the `constraints` branch would be needed. 