### PR TITLE
Add serialization for CRS, Commitment, and Proof

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -17,7 +17,6 @@ pub trait PrepareGadget<Unprepared, ConstraintF: PrimeField>: Sized {
 }
 
 /// A coefficient of `LinearCombination`.
-#[allow(non_camel_case_types)]
 #[derive(Clone)]
 pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Coefficient 1.

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -1,5 +1,6 @@
 use crate::{Polynomial, Rc, String, Vec};
 use ark_ff::Field;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{
     borrow::Borrow,
     marker::PhantomData,
@@ -12,7 +13,9 @@ pub type PolynomialLabel = String;
 
 /// Defines the minimal interface for public params for any polynomial
 /// commitment scheme.
-pub trait PCUniversalParams: Clone + core::fmt::Debug {
+pub trait PCUniversalParams:
+    Clone + core::fmt::Debug + CanonicalSerialize + CanonicalDeserialize
+{
     /// Outputs the maximum degree supported by the committer key.
     fn max_degree(&self) -> usize;
 }
@@ -48,7 +51,9 @@ pub trait PCPreparedVerifierKey<Unprepared: PCVerifierKey> {
 
 /// Defines the minimal interface of commitments for any polynomial
 /// commitment scheme.
-pub trait PCCommitment: Clone + ark_ff::ToBytes {
+pub trait PCCommitment:
+    Clone + ark_ff::ToBytes + CanonicalSerialize + CanonicalDeserialize
+{
     /// Outputs a non-hiding commitment to the zero polynomial.
     fn empty() -> Self;
 
@@ -87,7 +92,7 @@ pub trait PCRandomness: Clone {
 
 /// Defines the minimal interface of evaluation proofs for any polynomial
 /// commitment scheme.
-pub trait PCProof: Clone + ark_ff::ToBytes {
+pub trait PCProof: Clone + ark_ff::ToBytes + CanonicalSerialize + CanonicalDeserialize {
     /// Size in bytes
     fn size_in_bytes(&self) -> usize;
 }

--- a/src/ipa_pc/data_structures.rs
+++ b/src/ipa_pc/data_structures.rs
@@ -2,11 +2,15 @@ use crate::*;
 use crate::{PCCommitterKey, PCVerifierKey, Vec};
 use ark_ec::AffineCurve;
 use ark_ff::{Field, ToBytes, UniformRand, Zero};
-use ark_std::vec;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::{
+    io::{Read, Write},
+    vec,
+};
 use rand_core::RngCore;
 
 /// `UniversalParams` are the universal parameters for the inner product arg scheme.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Default(bound = ""), Clone(bound = ""), Debug(bound = ""))]
 pub struct UniversalParams<G: AffineCurve> {
     /// The key used to commit to polynomials.
@@ -83,7 +87,7 @@ impl<G: AffineCurve> PCPreparedVerifierKey<VerifierKey<G>> for PreparedVerifierK
 }
 
 /// Commitment to a polynomial that optionally enforces a degree bound.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -123,7 +127,7 @@ impl<G: AffineCurve> PCCommitment for Commitment<G> {
 
 impl<G: AffineCurve> ToBytes for Commitment<G> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.comm.write(&mut writer)?;
         let shifted_exists = self.shifted_comm.is_some();
         shifted_exists.write(&mut writer)?;
@@ -183,7 +187,7 @@ impl<G: AffineCurve> PCRandomness for Randomness<G> {
 }
 
 /// `Proof` is an evaluation proof that is output by `InnerProductArg::open`.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -220,7 +224,7 @@ impl<G: AffineCurve> PCProof for Proof<G> {
 
 impl<G: AffineCurve> ToBytes for Proof<G> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.l_vec.write(&mut writer)?;
         self.r_vec.write(&mut writer)?;
         self.final_comm_key.write(&mut writer)?;

--- a/src/kzg10/data_structures.rs
+++ b/src/kzg10/data_structures.rs
@@ -1,8 +1,10 @@
 use crate::*;
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{PrimeField, ToBytes, Zero};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
     borrow::Cow,
+    io::{Read, Write},
     marker::PhantomData,
     ops::{Add, AddAssign},
 };
@@ -20,7 +22,7 @@ pub struct UniversalParams<E: PairingEngine> {
     /// \beta times the above generator of G2.
     pub beta_h: E::G2Affine,
     /// Group elements of the form `{ \beta^i G2 }`, where `i` ranges from `0` to `-degree`.
-    pub prepared_neg_powers_of_h: BTreeMap<usize, E::G2Prepared>,
+    pub neg_powers_of_h: BTreeMap<usize, E::G2Affine>,
     /// The generator of G2, prepared for use in pairings.
     #[derivative(Debug = "ignore")]
     pub prepared_h: E::G2Prepared,
@@ -32,6 +34,47 @@ pub struct UniversalParams<E: PairingEngine> {
 impl<E: PairingEngine> PCUniversalParams for UniversalParams<E> {
     fn max_degree(&self) -> usize {
         self.powers_of_g.len() - 1
+    }
+}
+
+impl<E: PairingEngine> CanonicalSerialize for UniversalParams<E> {
+    fn serialize<W: Write>(&self, mut writer: W) -> Result<(), SerializationError> {
+        self.powers_of_g.serialize(&mut writer)?;
+        self.powers_of_gamma_g.serialize(&mut writer)?;
+        self.h.serialize(&mut writer)?;
+        self.beta_h.serialize(&mut writer)?;
+        self.neg_powers_of_h.serialize(&mut writer)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.powers_of_g.serialized_size()
+            + self.powers_of_gamma_g.serialized_size()
+            + self.h.serialized_size()
+            + self.beta_h.serialized_size()
+            + self.neg_powers_of_h.serialized_size()
+    }
+}
+
+impl<E: PairingEngine> CanonicalDeserialize for UniversalParams<E> {
+    fn deserialize<R: Read>(mut reader: R) -> Result<Self, SerializationError> {
+        let powers_of_g = Vec::<E::G1Affine>::deserialize(&mut reader)?;
+        let powers_of_gamma_g = BTreeMap::<usize, E::G1Affine>::deserialize(&mut reader)?;
+        let h = E::G2Affine::deserialize(&mut reader)?;
+        let beta_h = E::G2Affine::deserialize(&mut reader)?;
+        let neg_powers_of_h = BTreeMap::<usize, E::G2Affine>::deserialize(&mut reader)?;
+
+        let prepared_h = E::G2Prepared::from(h.clone());
+        let prepared_beta_h = E::G2Prepared::from(beta_h.clone());
+
+        Ok(Self {
+            powers_of_g,
+            powers_of_gamma_g,
+            h,
+            beta_h,
+            neg_powers_of_h,
+            prepared_h,
+            prepared_beta_h,
+        })
     }
 }
 
@@ -80,7 +123,7 @@ pub struct VerifierKey<E: PairingEngine> {
 
 impl<E: PairingEngine> ToBytes for VerifierKey<E> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.g.write(&mut writer)?;
         self.gamma_g.write(&mut writer)?;
         self.h.write(&mut writer)?;
@@ -124,7 +167,7 @@ impl<E: PairingEngine> PreparedVerifierKey<E> {
 }
 
 /// `Commitment` commits to a polynomial. It is output by `KZG10::commit`.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -141,7 +184,7 @@ pub struct Commitment<E: PairingEngine>(
 
 impl<E: PairingEngine> ToBytes for Commitment<E> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, writer: W) -> ark_std::io::Result<()> {
         self.0.write(writer)
     }
 }
@@ -285,7 +328,7 @@ impl<'a, F: PrimeField, P: UVPolynomial<F>> AddAssign<(F, &'a Randomness<F, P>)>
 }
 
 /// `Proof` is an evaluation proof that is output by `KZG10::open`.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -316,7 +359,7 @@ impl<E: PairingEngine> PCProof for Proof<E> {
 
 impl<E: PairingEngine> ToBytes for Proof<E> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.w.write(&mut writer)?;
         self.random_v
             .as_ref()

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -90,9 +90,8 @@ where
                 .enumerate()
                 .collect();
 
-        let prepared_neg_powers_of_h_time =
-            start_timer!(|| "Generating negative powers of h in G2");
-        let prepared_neg_powers_of_h = if produce_g2_powers {
+        let neg_powers_of_h_time = start_timer!(|| "Generating negative powers of h in G2");
+        let neg_powers_of_h = if produce_g2_powers {
             let mut neg_powers_of_beta = vec![E::Fr::one()];
             let mut cur = E::Fr::one() / &beta;
             for _ in 0..max_degree {
@@ -110,19 +109,15 @@ where
 
             let affines = E::G2Projective::batch_normalization_into_affine(&neg_powers_of_h);
             let mut affines_map = BTreeMap::new();
-            affines
-                .into_iter()
-                .enumerate()
-                .map(|(i, a)| (i, a.into()))
-                .for_each(|(i, a)| {
-                    affines_map.insert(i, a);
-                });
+            affines.into_iter().enumerate().for_each(|(i, a)| {
+                affines_map.insert(i, a);
+            });
             affines_map
         } else {
             BTreeMap::new()
         };
 
-        end_timer!(prepared_neg_powers_of_h_time);
+        end_timer!(neg_powers_of_h_time);
 
         let h = h.into_affine();
         let beta_h = h.mul(beta).into_affine();
@@ -134,7 +129,7 @@ where
             powers_of_gamma_g,
             h,
             beta_h,
-            prepared_neg_powers_of_h,
+            neg_powers_of_h,
             prepared_h,
             prepared_beta_h,
         };

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -461,8 +461,8 @@ mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_bls12_381::Fr;
     use ark_ec::PairingEngine;
-    use ark_ff::test_rng;
     use ark_poly::univariate::DensePolynomial as DensePoly;
+    use ark_std::test_rng;
 
     type UniPoly_381 = DensePoly<<Bls12_381 as PairingEngine>::Fr>;
     type UniPoly_377 = DensePoly<<Bls12_377 as PairingEngine>::Fr>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -669,8 +669,9 @@ fn lc_query_set_to_poly_query_set<'a, F: Field, T: Clone + Ord>(
 #[cfg(test)]
 pub mod tests {
     use crate::*;
-    use ark_ff::{test_rng, Field};
+    use ark_ff::Field;
     use ark_poly::Polynomial;
+    use ark_std::test_rng;
     use rand::{distributions::Distribution, Rng};
 
     struct TestInfo<F: Field, P: Polynomial<F>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use constraints::*;
 
 /// Errors pertaining to query sets.
 pub mod error;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 pub use error::*;
 
 /// A random number generator that bypasses some limitations of the Rust borrow
@@ -135,7 +136,11 @@ pub trait PolynomialCommitment<F: Field, P: Polynomial<F>>: Sized {
     /// The evaluation proof for a single point.
     type Proof: PCProof + Clone;
     /// The evaluation proof for a query set.
-    type BatchProof: Clone + From<Vec<Self::Proof>> + Into<Vec<Self::Proof>>;
+    type BatchProof: Clone
+        + From<Vec<Self::Proof>>
+        + Into<Vec<Self::Proof>>
+        + CanonicalSerialize
+        + CanonicalDeserialize;
     /// The error type for the scheme.
     type Error: ark_std::error::Error + From<Error>;
 

--- a/src/marlin_pc/data_structures.rs
+++ b/src/marlin_pc/data_structures.rs
@@ -4,6 +4,8 @@ use crate::{
 };
 use ark_ec::{PairingEngine, ProjectiveCurve};
 use ark_ff::{PrimeField, ToBytes};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::io::{Read, Write};
 use ark_std::ops::{Add, AddAssign};
 use rand_core::RngCore;
 
@@ -132,7 +134,7 @@ impl<E: PairingEngine> PCVerifierKey for VerifierKey<E> {
 
 impl<E: PairingEngine> ToBytes for VerifierKey<E> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.vk.write(&mut writer)?;
         if let Some(degree_bounds_and_shift_powers) = &self.degree_bounds_and_shift_powers {
             writer.write_all(&degree_bounds_and_shift_powers.len().to_le_bytes())?;
@@ -205,7 +207,7 @@ impl<E: PairingEngine> PCPreparedVerifierKey<VerifierKey<E>> for PreparedVerifie
 }
 
 /// Commitment to a polynomial that optionally enforces a degree bound.
-#[derive(Derivative)]
+#[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(
     Default(bound = ""),
     Hash(bound = ""),
@@ -227,7 +229,7 @@ pub struct Commitment<E: PairingEngine> {
 
 impl<E: PairingEngine> ToBytes for Commitment<E> {
     #[inline]
-    fn write<W: ark_std::io::Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
+    fn write<W: Write>(&self, mut writer: W) -> ark_std::io::Result<()> {
         self.comm.write(&mut writer)?;
         let shifted_exists = self.shifted_comm.is_some();
         shifted_exists.write(&mut writer)?;

--- a/src/sonic_pc/mod.rs
+++ b/src/sonic_pc/mod.rs
@@ -161,7 +161,7 @@ where
         enforced_degree_bounds: Option<&[usize]>,
     ) -> Result<(Self::CommitterKey, Self::VerifierKey), Self::Error> {
         let trim_time = start_timer!(|| "Trimming public parameters");
-        let prepared_neg_powers_of_h = &pp.prepared_neg_powers_of_h;
+        let neg_powers_of_h = &pp.neg_powers_of_h;
         let max_degree = pp.max_degree();
         if supported_degree > max_degree {
             return Err(Error::TrimmingDegreeTooLarge);
@@ -221,7 +221,7 @@ where
                     .map(|bound| {
                         (
                             *bound,
-                            prepared_neg_powers_of_h[&(max_degree - *bound)].clone(),
+                            neg_powers_of_h[&(max_degree - *bound)].clone().into(),
                         )
                     })
                     .collect();


### PR DESCRIPTION
This PR requires all CRS, commitments, and proofs in `poly-commit` to support `CanonicalSerialize` and `CanonicalDeserialize`.