### PR TITLE
The non-constraint part of the Constraints PR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ digest = "0.9"
 rayon = { version = "1", optional = true }
 derivative = { version = "2", features = [ "use_core" ] }
 
+tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
+
 [dev-dependencies]
 rand = { version = "0.7", default-features = false }
 ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-features = false }
@@ -60,7 +62,7 @@ debug = true
 
 [features]
 default = [ "std", "parallel" ]
-std = [ "ark-ff/std", "ark-ec/std", "ark-poly/std", "ark-std/std", "ark-serialize/std" ]
+std = [ "ark-ff/std", "ark-ec/std", "ark-nonnative-field/std", "ark-poly/std", "ark-std/std", "ark-relations/std", "ark-serialize/std" ]
 r1cs = [ "ark-relations", "ark-r1cs-std", "ark-nonnative-field", "hashbrown" ]
 print-trace = [ "bench-utils/print-trace" ]
 parallel = [ "std", "ark-ff/parallel", "ark-ec/parallel", "ark-poly/parallel", "ark-std/parallel", "rayon" ]

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -73,7 +73,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// A collection of random data used in the polynomial commitment checking.
 pub struct PCCheckRandomDataVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Opening challenges.

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -1,5 +1,5 @@
 use crate::{Polynomial, PolynomialCommitment, Rc, String, Vec};
-use ark_ff::Field;
+use ark_ff::{Field, ToConstraintField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::{
     borrow::Borrow,
@@ -190,6 +190,14 @@ pub struct LabeledCommitment<C: PCCommitment> {
     label: PolynomialLabel,
     commitment: C,
     degree_bound: Option<usize>,
+}
+
+impl<F: Field, C: PCCommitment + ToConstraintField<F>> ToConstraintField<F>
+    for LabeledCommitment<C>
+{
+    fn to_field_elements(&self) -> Option<Vec<F>> {
+        self.commitment.to_field_elements()
+    }
 }
 
 impl<C: PCCommitment> LabeledCommitment<C> {


### PR DESCRIPTION
As part of the efforts to end the long-term battle with constraints PR, I made this mini-constraints PR that finalizes all the non-constraints changes. This is also aimed to decompress the Constraint PR.

All the changes here fit into the consensus of #47. The rest of #47 is therefore to focus on the `constraints.rs`.