### PR TITLE
Replace `rand`/`rand_core` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-featur
 ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false, optional = true }
 hashbrown = { version = "0.9", optional = true }
 
-rand_core = { version = "0.5", default-features = false }
 digest = "0.9"
 rayon = { version = "1", optional = true }
 derivative = { version = "2", features = [ "use_core" ] }
@@ -40,7 +39,6 @@ derivative = { version = "2", features = [ "use_core" ] }
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 
 [dev-dependencies]
-rand = { version = "0.7", default-features = false }
 ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-features = false }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve" ] }
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve" ] }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -1,13 +1,13 @@
 use crate::{Polynomial, PolynomialCommitment, Rc, String, Vec};
 use ark_ff::{Field, ToConstraintField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::rand::RngCore;
 use ark_std::{
     borrow::Borrow,
     io::{Read, Write},
     marker::PhantomData,
     ops::{AddAssign, MulAssign, SubAssign},
 };
-use rand_core::RngCore;
 
 /// Labels a `LabeledPolynomial` or a `LabeledCommitment`.
 pub type PolynomialLabel = String;

--- a/src/ipa_pc/data_structures.rs
+++ b/src/ipa_pc/data_structures.rs
@@ -3,11 +3,11 @@ use crate::{PCCommitterKey, PCVerifierKey, Vec};
 use ark_ec::AffineCurve;
 use ark_ff::{Field, ToBytes, UniformRand, Zero};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
+use ark_std::rand::RngCore;
 use ark_std::{
     io::{Read, Write},
     vec,
 };
-use rand_core::RngCore;
 
 /// `UniversalParams` are the universal parameters for the inner product arg scheme.
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]

--- a/src/ipa_pc/mod.rs
+++ b/src/ipa_pc/mod.rs
@@ -1034,29 +1034,22 @@ mod tests {
     use ark_ed_on_bls12_381::{EdwardsAffine, Fr};
     use ark_ff::PrimeField;
     use ark_poly::{univariate::DensePolynomial as DensePoly, UVPolynomial};
+    use ark_std::rand::rngs::StdRng;
     use blake2::Blake2s;
 
     type UniPoly = DensePoly<Fr>;
     type PC<E, D, P> = InnerProductArgPC<E, D, P>;
     type PC_JJB2S = PC<EdwardsAffine, Blake2s, UniPoly>;
 
-    fn rand_poly<F: PrimeField>(
-        degree: usize,
-        _: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
-    ) -> DensePoly<F> {
+    fn rand_poly<F: PrimeField>(degree: usize, _: Option<usize>, rng: &mut StdRng) -> DensePoly<F> {
         DensePoly::rand(degree, rng)
     }
 
-    fn constant_poly<F: PrimeField>(
-        _: usize,
-        _: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
-    ) -> DensePoly<F> {
+    fn constant_poly<F: PrimeField>(_: usize, _: Option<usize>, rng: &mut StdRng) -> DensePoly<F> {
         DensePoly::from_coefficients_slice(&[F::rand(rng)])
     }
 
-    fn rand_point<F: PrimeField>(_: Option<usize>, rng: &mut rand::prelude::StdRng) -> F {
+    fn rand_point<F: PrimeField>(_: Option<usize>, rng: &mut StdRng) -> F {
         F::rand(rng)
     }
 

--- a/src/ipa_pc/mod.rs
+++ b/src/ipa_pc/mod.rs
@@ -5,8 +5,8 @@ use crate::{PCCommitterKey, PCRandomness, PCUniversalParams, PolynomialCommitmen
 
 use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
+use ark_std::rand::RngCore;
 use ark_std::{convert::TryInto, format, marker::PhantomData, vec};
-use rand_core::RngCore;
 
 mod data_structures;
 pub use data_structures::*;

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -12,7 +12,7 @@ use ark_ff::{One, PrimeField, UniformRand, Zero};
 use ark_poly::UVPolynomial;
 use ark_std::{format, marker::PhantomData, ops::Div, vec};
 
-use rand_core::RngCore;
+use ark_std::rand::RngCore;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,8 +685,12 @@ pub mod tests {
     use crate::*;
     use ark_ff::Field;
     use ark_poly::Polynomial;
+    use ark_std::rand::{
+        distributions::{Distribution, Uniform},
+        rngs::StdRng,
+        Rng,
+    };
     use ark_std::test_rng;
-    use rand::{distributions::Distribution, Rng};
 
     struct TestInfo<F: Field, P: Polynomial<F>> {
         num_iters: usize,
@@ -697,13 +701,13 @@ pub mod tests {
         enforce_degree_bounds: bool,
         max_num_queries: usize,
         num_equations: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     }
 
     pub fn bad_degree_bound_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -714,7 +718,7 @@ pub mod tests {
         let max_degree = 100;
         let pp = PC::setup(max_degree, None, rng)?;
         for _ in 0..10 {
-            let supported_degree = rand::distributions::Uniform::from(1..=max_degree).sample(rng);
+            let supported_degree = Uniform::from(1..=max_degree).sample(rng);
             assert!(
                 max_degree >= supported_degree,
                 "max_degree < supported_degree"
@@ -812,14 +816,14 @@ pub mod tests {
         let rng = &mut test_rng();
         // If testing multivariate polynomials, make the max degree lower
         let max_degree = match num_vars {
-            Some(_) => max_degree.unwrap_or(rand::distributions::Uniform::from(2..=10).sample(rng)),
-            None => max_degree.unwrap_or(rand::distributions::Uniform::from(2..=64).sample(rng)),
+            Some(_) => max_degree.unwrap_or(Uniform::from(2..=10).sample(rng)),
+            None => max_degree.unwrap_or(Uniform::from(2..=64).sample(rng)),
         };
         let pp = PC::setup(max_degree, num_vars, rng)?;
 
         for _ in 0..num_iters {
-            let supported_degree = supported_degree
-                .unwrap_or(rand::distributions::Uniform::from(1..=max_degree).sample(rng));
+            let supported_degree =
+                supported_degree.unwrap_or(Uniform::from(1..=max_degree).sample(rng));
             assert!(
                 max_degree >= supported_degree,
                 "max_degree < supported_degree"
@@ -835,14 +839,13 @@ pub mod tests {
             println!("Sampled supported degree");
 
             // Generate polynomials
-            let num_points_in_query_set =
-                rand::distributions::Uniform::from(1..=max_num_queries).sample(rng);
+            let num_points_in_query_set = Uniform::from(1..=max_num_queries).sample(rng);
             for i in 0..num_polynomials {
                 let label = format!("Test{}", i);
                 labels.push(label.clone());
-                let degree = rand::distributions::Uniform::from(1..=supported_degree).sample(rng);
+                let degree = Uniform::from(1..=supported_degree).sample(rng);
                 let degree_bound = if let Some(degree_bounds) = &mut degree_bounds {
-                    let range = rand::distributions::Uniform::from(degree..=supported_degree);
+                    let range = Uniform::from(degree..=supported_degree);
                     let degree_bound = range.sample(rng);
                     degree_bounds.push(degree_bound);
                     Some(degree_bound)
@@ -950,14 +953,14 @@ pub mod tests {
         let rng = &mut test_rng();
         // If testing multivariate polynomials, make the max degree lower
         let max_degree = match num_vars {
-            Some(_) => max_degree.unwrap_or(rand::distributions::Uniform::from(2..=10).sample(rng)),
-            None => max_degree.unwrap_or(rand::distributions::Uniform::from(2..=64).sample(rng)),
+            Some(_) => max_degree.unwrap_or(Uniform::from(2..=10).sample(rng)),
+            None => max_degree.unwrap_or(Uniform::from(2..=64).sample(rng)),
         };
         let pp = PC::setup(max_degree, num_vars, rng)?;
 
         for _ in 0..num_iters {
-            let supported_degree = supported_degree
-                .unwrap_or(rand::distributions::Uniform::from(1..=max_degree).sample(rng));
+            let supported_degree =
+                supported_degree.unwrap_or(Uniform::from(1..=max_degree).sample(rng));
             assert!(
                 max_degree >= supported_degree,
                 "max_degree < supported_degree"
@@ -973,15 +976,14 @@ pub mod tests {
             println!("Sampled supported degree");
 
             // Generate polynomials
-            let num_points_in_query_set =
-                rand::distributions::Uniform::from(1..=max_num_queries).sample(rng);
+            let num_points_in_query_set = Uniform::from(1..=max_num_queries).sample(rng);
             for i in 0..num_polynomials {
                 let label = format!("Test{}", i);
                 labels.push(label.clone());
-                let degree = rand::distributions::Uniform::from(1..=supported_degree).sample(rng);
+                let degree = Uniform::from(1..=supported_degree).sample(rng);
                 let degree_bound = if let Some(degree_bounds) = &mut degree_bounds {
                     if rng.gen() {
-                        let range = rand::distributions::Uniform::from(degree..=supported_degree);
+                        let range = Uniform::from(degree..=supported_degree);
                         let degree_bound = range.sample(rng);
                         degree_bounds.push(degree_bound);
                         Some(degree_bound)
@@ -1108,8 +1110,8 @@ pub mod tests {
 
     pub fn single_poly_test<F, P, PC>(
         num_vars: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1132,8 +1134,8 @@ pub mod tests {
     }
 
     pub fn linear_poly_degree_bound_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1156,8 +1158,8 @@ pub mod tests {
     }
 
     pub fn single_poly_degree_bound_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1180,8 +1182,8 @@ pub mod tests {
     }
 
     pub fn quadratic_poly_degree_bound_multiple_queries_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1204,8 +1206,8 @@ pub mod tests {
     }
 
     pub fn single_poly_degree_bound_multiple_queries_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1228,8 +1230,8 @@ pub mod tests {
     }
 
     pub fn two_polys_degree_bound_single_query_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1253,8 +1255,8 @@ pub mod tests {
 
     pub fn full_end_to_end_test<F, P, PC>(
         num_vars: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1278,8 +1280,8 @@ pub mod tests {
 
     pub fn full_end_to_end_equation_test<F, P, PC>(
         num_vars: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1303,8 +1305,8 @@ pub mod tests {
 
     pub fn single_equation_test<F, P, PC>(
         num_vars: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1328,8 +1330,8 @@ pub mod tests {
 
     pub fn two_equation_test<F, P, PC>(
         num_vars: Option<usize>,
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,
@@ -1352,8 +1354,8 @@ pub mod tests {
     }
 
     pub fn two_equation_degree_bound_test<F, P, PC>(
-        rand_poly: fn(usize, Option<usize>, &mut rand::prelude::StdRng) -> P,
-        rand_point: fn(Option<usize>, &mut rand::prelude::StdRng) -> P::Point,
+        rand_poly: fn(usize, Option<usize>, &mut StdRng) -> P,
+        rand_point: fn(Option<usize>, &mut StdRng) -> P::Point,
     ) -> Result<(), PC::Error>
     where
         F: Field,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate ark_std;
 
 use ark_ff::Field;
 pub use ark_poly::{Polynomial, UVPolynomial};
-use rand_core::RngCore;
+use ark_std::rand::RngCore;
 
 use ark_std::{
     collections::{BTreeMap, BTreeSet},

--- a/src/marlin/marlin_pc/data_structures.rs
+++ b/src/marlin/marlin_pc/data_structures.rs
@@ -7,7 +7,7 @@ use ark_ff::{Field, PrimeField, ToBytes, ToConstraintField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
 use ark_std::io::{Read, Write};
 use ark_std::ops::{Add, AddAssign};
-use rand_core::RngCore;
+use ark_std::rand::RngCore;
 
 use crate::kzg10;
 /// `UniversalParams` are the universal parameters for the KZG10 scheme.

--- a/src/marlin/marlin_pc/mod.rs
+++ b/src/marlin/marlin_pc/mod.rs
@@ -539,6 +539,7 @@ mod tests {
     use ark_ec::PairingEngine;
     use ark_ff::UniformRand;
     use ark_poly::{univariate::DensePolynomial as DensePoly, UVPolynomial};
+    use ark_std::rand::rngs::StdRng;
 
     type UniPoly_381 = DensePoly<<Bls12_381 as PairingEngine>::Fr>;
     type UniPoly_377 = DensePoly<<Bls12_377 as PairingEngine>::Fr>;
@@ -550,7 +551,7 @@ mod tests {
     fn rand_poly<E: PairingEngine>(
         degree: usize,
         _: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
+        rng: &mut StdRng,
     ) -> DensePoly<E::Fr> {
         DensePoly::<E::Fr>::rand(degree, rng)
     }
@@ -558,12 +559,12 @@ mod tests {
     fn constant_poly<E: PairingEngine>(
         _: usize,
         _: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
+        rng: &mut StdRng,
     ) -> DensePoly<E::Fr> {
         DensePoly::<E::Fr>::from_coefficients_slice(&[E::Fr::rand(rng)])
     }
 
-    fn rand_point<E: PairingEngine>(_: Option<usize>, rng: &mut rand::prelude::StdRng) -> E::Fr {
+    fn rand_point<E: PairingEngine>(_: Option<usize>, rng: &mut StdRng) -> E::Fr {
         E::Fr::rand(rng)
     }
 

--- a/src/marlin/marlin_pc/mod.rs
+++ b/src/marlin/marlin_pc/mod.rs
@@ -6,8 +6,8 @@ use crate::{PCRandomness, PCUniversalParams, PolynomialCommitment};
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::Zero;
 use ark_poly::UVPolynomial;
+use ark_std::rand::RngCore;
 use ark_std::{marker::PhantomData, ops::Div, vec};
-use rand_core::RngCore;
 
 mod data_structures;
 pub use data_structures::*;

--- a/src/marlin/marlin_pst13_pc/data_structures.rs
+++ b/src/marlin/marlin_pst13_pc/data_structures.rs
@@ -12,7 +12,7 @@ use ark_std::{
 };
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError};
-use rand_core::RngCore;
+use ark_std::rand::RngCore;
 
 /// `UniversalParams` are the universal parameters for the MarlinPST13 scheme.
 #[derive(Derivative)]

--- a/src/marlin/marlin_pst13_pc/mod.rs
+++ b/src/marlin/marlin_pst13_pc/mod.rs
@@ -722,6 +722,7 @@ mod tests {
         multivariate::{SparsePolynomial as SparsePoly, SparseTerm},
         MVPolynomial,
     };
+    use ark_std::rand::rngs::StdRng;
 
     type MVPoly_381 = SparsePoly<<Bls12_381 as PairingEngine>::Fr, SparseTerm>;
     type MVPoly_377 = SparsePoly<<Bls12_377 as PairingEngine>::Fr, SparseTerm>;
@@ -733,15 +734,12 @@ mod tests {
     fn rand_poly<E: PairingEngine>(
         degree: usize,
         num_vars: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
+        rng: &mut StdRng,
     ) -> SparsePoly<E::Fr, SparseTerm> {
         SparsePoly::<E::Fr, SparseTerm>::rand(degree, num_vars.unwrap(), rng)
     }
 
-    fn rand_point<E: PairingEngine>(
-        num_vars: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
-    ) -> Vec<E::Fr> {
+    fn rand_point<E: PairingEngine>(num_vars: Option<usize>, rng: &mut StdRng) -> Vec<E::Fr> {
         let num_vars = num_vars.unwrap();
         let mut point = Vec::with_capacity(num_vars);
         for _ in 0..num_vars {

--- a/src/marlin/marlin_pst13_pc/mod.rs
+++ b/src/marlin/marlin_pst13_pc/mod.rs
@@ -12,8 +12,8 @@ use ark_ec::{
 };
 use ark_ff::{One, PrimeField, UniformRand, Zero};
 use ark_poly::{multivariate::Term, MVPolynomial};
+use ark_std::rand::RngCore;
 use ark_std::{marker::PhantomData, ops::Index, vec};
-use rand_core::RngCore;
 
 mod data_structures;
 pub use data_structures::*;

--- a/src/multilinear_pc/mod.rs
+++ b/src/multilinear_pc/mod.rs
@@ -268,9 +268,9 @@ mod tests {
     use ark_bls12_381::Bls12_381;
     use ark_ec::PairingEngine;
     use ark_poly::{DenseMultilinearExtension, MultilinearExtension, SparseMultilinearExtension};
+    use ark_std::rand::RngCore;
     use ark_std::vec::Vec;
     use ark_std::{test_rng, UniformRand};
-    use rand_core::RngCore;
     type E = Bls12_381;
     type Fr = <E as PairingEngine>::Fr;
 

--- a/src/multilinear_pc/mod.rs
+++ b/src/multilinear_pc/mod.rs
@@ -9,9 +9,9 @@ use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
 use ark_std::collections::LinkedList;
 use ark_std::iter::FromIterator;
 use ark_std::marker::PhantomData;
+use ark_std::rand::RngCore;
 use ark_std::vec::Vec;
 use ark_std::UniformRand;
-use rand_core::RngCore;
 
 /// data structures used by multilinear extension commitment scheme
 pub mod data_structures;

--- a/src/optional_rng.rs
+++ b/src/optional_rng.rs
@@ -1,5 +1,5 @@
+use ark_std::rand::RngCore;
 use core::num::NonZeroU32;
-use rand_core::RngCore;
 
 /// `OptionalRng` is a hack that is necessary because `Option<&mut R>` is not implicitly reborrowed
 /// like `&mut R` is. This causes problems when a variable of type `Option<&mut R>`
@@ -35,10 +35,10 @@ impl<R: RngCore> RngCore for OptionalRng<R> {
     }
 
     #[inline]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), ark_std::rand::Error> {
         match &mut self.0 {
             Some(r) => r.try_fill_bytes(dest),
-            None => Err(NonZeroU32::new(rand_core::Error::CUSTOM_START)
+            None => Err(NonZeroU32::new(ark_std::rand::Error::CUSTOM_START)
                 .unwrap()
                 .into()),
         }

--- a/src/sonic_pc/mod.rs
+++ b/src/sonic_pc/mod.rs
@@ -682,6 +682,7 @@ mod tests {
     use ark_ec::PairingEngine;
     use ark_ff::UniformRand;
     use ark_poly::{univariate::DensePolynomial as DensePoly, UVPolynomial};
+    use ark_std::rand::rngs::StdRng;
 
     type UniPoly_381 = DensePoly<<Bls12_381 as PairingEngine>::Fr>;
     type UniPoly_377 = DensePoly<<Bls12_377 as PairingEngine>::Fr>;
@@ -693,12 +694,12 @@ mod tests {
     fn rand_poly<E: PairingEngine>(
         degree: usize,
         _: Option<usize>,
-        rng: &mut rand::prelude::StdRng,
+        rng: &mut StdRng,
     ) -> DensePoly<E::Fr> {
         DensePoly::<E::Fr>::rand(degree, rng)
     }
 
-    fn rand_point<E: PairingEngine>(_: Option<usize>, rng: &mut rand::prelude::StdRng) -> E::Fr {
+    fn rand_point<E: PairingEngine>(_: Option<usize>, rng: &mut StdRng) -> E::Fr {
         E::Fr::rand(rng)
     }
 

--- a/src/sonic_pc/mod.rs
+++ b/src/sonic_pc/mod.rs
@@ -6,8 +6,8 @@ use crate::{PCRandomness, PCUniversalParams, PolynomialCommitment};
 
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, UniformRand, Zero};
+use ark_std::rand::RngCore;
 use ark_std::{convert::TryInto, marker::PhantomData, ops::Div, vec};
-use rand_core::RngCore;
 
 mod data_structures;
 pub use data_structures::*;


### PR DESCRIPTION
## Description

This PR replaces the use of `rand` or `rand_core` to `ark_std::rand`.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` --- N/A, does not affect a developer.
- [x] Re-reviewed `Files changed` in the Github PR explorer
