### PR TITLE
Fix MarlinPC's CommitterKey to return the correct supported_degree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Pending
+- MarlinPC's `supported_degree` fix.
 
 ### Breaking changes
 

--- a/src/marlin/marlin_pc/data_structures.rs
+++ b/src/marlin/marlin_pc/data_structures.rs
@@ -88,7 +88,7 @@ impl<E: PairingEngine> PCCommitterKey for CommitterKey<E> {
     }
 
     fn supported_degree(&self) -> usize {
-        self.powers.len()
+        self.powers.len() - 1
     }
 }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Fixes MarlinPC's CommitterKey `supported_degree` function to return the correct degree from the number of powers. The number of elements in powers is equal to `supported_degree + 1`, as specified in the `trim` function here: https://github.com/arkworks-rs/poly-commit/blob/9698a9b4866e962fb6e75fae4a521f8621915469/src/marlin/marlin_pc/mod.rs#L96

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [NA] Wrote unit tests (Existing unit tests use `supported_degree` already to generate polynomials)
- [NA] Updated relevant documentation in the code (Existing documentation is sufficient)
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer