### PR TITLE
Fix the URL of Papamanthou-Shi-Tamassia multivariate PC

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -62,7 +62,7 @@ Multivariate polynomial commitment based on the construction in the Papamanthou-
 
 The construction is described in the following paper.
 
-[pst]: https://ia.cr.org/2011/587
+[pst]: https://ia.cr/2011/587
 
 [Signatures of Correct Computation][pst]    
 Charalampos Papamanthou, Elaine Shi, Roberto Tamassia   


### PR DESCRIPTION
## Description

Note that the link to PST paper is https://ia.cr/2011/587 instead of https://ia.cr.org/2011/587

This PR fixes this.
---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Re-reviewed `Files changed` in the Github PR explorer

N/A:
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`