### PR TITLE
Update `PC::check_combinations` to optional rng

### DIFF
--- a/src/ipa_pc/mod.rs
+++ b/src/ipa_pc/mod.rs
@@ -701,14 +701,14 @@ where
         })
     }
 
-    fn check<'a>(
+    fn check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         values: impl IntoIterator<Item = G::ScalarField>,
         proof: &Self::Proof,
         opening_challenges: &mut ChallengeGenerator<G::ScalarField, S>,
-        _rng: Option<&mut dyn RngCore>,
+        _rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -759,11 +759,12 @@ where
         values: &Evaluations<G::ScalarField, P::Point>,
         proof: &Self::BatchProof,
         opening_challenges: &mut ChallengeGenerator<G::ScalarField, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
     {
+        let rng = &mut crate::optional_rng::OptionalRng(rng);
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
 
@@ -956,7 +957,7 @@ where
         eqn_evaluations: &Evaluations<P::Point, G::ScalarField>,
         proof: &BatchLCProof<G::ScalarField, Self::BatchProof>,
         opening_challenges: &mut ChallengeGenerator<G::ScalarField, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -321,11 +321,12 @@ where
         points: &[E::Fr],
         values: &[E::Fr],
         proofs: &[Proof<E>],
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Error> {
         let check_time =
             start_timer!(|| format!("Checking {} evaluation proofs", commitments.len()));
 
+        let rng = &mut crate::optional_rng::OptionalRng(rng);
         let mut total_c = <E::G1Projective>::zero();
         let mut total_w = <E::G1Projective>::zero();
 
@@ -616,7 +617,12 @@ mod tests {
                 proofs.push(proof);
             }
             assert!(KZG10::<E, P>::batch_check(
-                &vk, &comms, &points, &values, &proofs, rng
+                &vk,
+                &comms,
+                &points,
+                &values,
+                &proofs,
+                Some(rng)
             )?);
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,14 +222,14 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         Self::Commitment: 'a;
 
     /// check but with individual challenges
-    fn check<'a>(
+    fn check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         values: impl IntoIterator<Item = F>,
         proof: &Self::Proof,
         challenge_generator: &mut ChallengeGenerator<F, S>,
-        rng: Option<&mut dyn RngCore>,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a;
@@ -242,7 +242,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         evaluations: &Evaluations<P::Point, F>,
         proof: &Self::BatchProof,
         challenge_generator: &mut ChallengeGenerator<F, S>,
-        rng: &mut R,
+        mut rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -289,7 +289,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
                 values,
                 &proof,
                 challenge_generator,
-                Some(rng),
+                rng.as_mut(),
             )?;
             end_timer!(proof_time);
         }
@@ -341,7 +341,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         eqn_evaluations: &Evaluations<P::Point, F>,
         proof: &BatchLCProof<F, Self::BatchProof>,
         challenge_generator: &mut ChallengeGenerator<F, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -638,7 +638,7 @@ pub mod tests {
                     &values,
                     &proof,
                     &mut (challenge_gen.clone()),
-                    rng,
+                    Some(rng),
                 )?;
                 assert!(result, "proof was incorrect, Query set: {:#?}", query_set);
             }
@@ -774,7 +774,7 @@ pub mod tests {
                     &values,
                     &proof,
                     &mut (challenge_gen.clone()),
-                    rng,
+                    Some(rng),
                 )?;
                 if !result {
                     println!(
@@ -955,7 +955,7 @@ pub mod tests {
                     &values,
                     &proof,
                     &mut (challenge_gen.clone()),
-                    rng,
+                    Some(rng),
                 )?;
                 if !result {
                     println!(

--- a/src/marlin/marlin_pc/mod.rs
+++ b/src/marlin/marlin_pc/mod.rs
@@ -349,14 +349,14 @@ where
 
     /// Verifies that `value` is the evaluation at `x` of the polynomial
     /// committed inside `comm`.
-    fn check<'a>(
+    fn check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         values: impl IntoIterator<Item = E::Fr>,
         proof: &Self::Proof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        _rng: Option<&mut dyn RngCore>,
+        _rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -382,7 +382,7 @@ where
         values: &Evaluations<E::Fr, P::Point>,
         proof: &Self::BatchProof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -446,7 +446,7 @@ where
         evaluations: &Evaluations<E::Fr, P::Point>,
         proof: &BatchLCProof<E::Fr, Self::BatchProof>,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,

--- a/src/marlin/marlin_pst13_pc/mod.rs
+++ b/src/marlin/marlin_pst13_pc/mod.rs
@@ -540,14 +540,14 @@ where
 
     /// Verifies that `value` is the evaluation at `x` of the polynomial
     /// committed inside `comm`.
-    fn check<'a>(
+    fn check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         values: impl IntoIterator<Item = E::Fr>,
         proof: &Self::Proof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        _rng: Option<&mut dyn RngCore>,
+        _rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -590,11 +590,12 @@ where
         values: &Evaluations<P::Point, E::Fr>,
         proof: &Self::BatchProof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
     {
+        let rng = &mut crate::optional_rng::OptionalRng(rng);
         let (combined_comms, combined_queries, combined_evals) =
             Marlin::<E, S, P, Self>::combine_and_normalize(
                 commitments,
@@ -696,7 +697,7 @@ where
         eqn_evaluations: &Evaluations<P::Point, E::Fr>,
         proof: &BatchLCProof<E::Fr, Self::BatchProof>,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,

--- a/src/marlin/mod.rs
+++ b/src/marlin/mod.rs
@@ -328,7 +328,7 @@ where
         evaluations: &Evaluations<P::Point, E::Fr>,
         proof: &BatchLCProof<E::Fr, PC::BatchProof>,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Error>
     where
         R: RngCore,

--- a/src/sonic_pc/mod.rs
+++ b/src/sonic_pc/mod.rs
@@ -385,14 +385,14 @@ where
         Ok(proof)
     }
 
-    fn check<'a>(
+    fn check<'a, R: RngCore>(
         vk: &Self::VerifierKey,
         commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
         point: &'a P::Point,
         values: impl IntoIterator<Item = E::Fr>,
         proof: &Self::Proof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        _rng: Option<&mut dyn RngCore>,
+        _rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
@@ -432,11 +432,12 @@ where
         values: &Evaluations<E::Fr, P::Point>,
         proof: &Self::BatchProof,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,
     {
+        let rng = &mut crate::optional_rng::OptionalRng(rng);
         let commitments: BTreeMap<_, _> = commitments.into_iter().map(|c| (c.label(), c)).collect();
         let mut query_to_labels_map = BTreeMap::new();
 
@@ -600,7 +601,7 @@ where
         eqn_evaluations: &Evaluations<P::Point, E::Fr>,
         proof: &BatchLCProof<E::Fr, Self::BatchProof>,
         opening_challenges: &mut ChallengeGenerator<E::Fr, S>,
-        rng: &mut R,
+        rng: Option<&mut R>,
     ) -> Result<bool, Self::Error>
     where
         Self::Commitment: 'a,


### PR DESCRIPTION
Closes #96

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Update `PC::check_combinations` and `PC::batch_check` to take the rng as optional. Will fix downstream problems with marlin

closes: #96 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master) - N/A, the purpose is to prepare `constraints` to be merged
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests - N/A, only preparing to release
- [ ] Updated relevant documentation in the code - N/A, only preparing to release
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` - N/A, only preparing to release
- [x] Re-reviewed `Files changed` in the Github PR explorer
