### PR TITLE
Deprecate .size_in_bytes() in favor of .serialized_size()

### DIFF
--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -66,7 +66,10 @@ pub trait PCCommitment:
     fn has_degree_bound(&self) -> bool;
 
     /// Size in bytes
-    fn size_in_bytes(&self) -> usize;
+    #[deprecated(since = "0.4.0", note = "Please use `.serialized_size()` instead.")]
+    fn size_in_bytes(&self) -> usize {
+        self.serialized_size()
+    }
 }
 
 /// Defines the minimal interface of prepared commitments for any polynomial
@@ -99,7 +102,10 @@ pub trait PCRandomness: Clone + CanonicalSerialize + CanonicalDeserialize {
 /// commitment scheme.
 pub trait PCProof: Clone + ark_ff::ToBytes + CanonicalSerialize + CanonicalDeserialize {
     /// Size in bytes
-    fn size_in_bytes(&self) -> usize;
+    #[deprecated(since = "0.4.0", note = "Please use `.serialized_size()` instead.")]
+    fn size_in_bytes(&self) -> usize {
+        self.serialized_size()
+    }
 }
 
 /// A proof of satisfaction of linear combinations.

--- a/src/ipa_pc/data_structures.rs
+++ b/src/ipa_pc/data_structures.rs
@@ -119,10 +119,6 @@ impl<G: AffineCurve> PCCommitment for Commitment<G> {
     fn has_degree_bound(&self) -> bool {
         false
     }
-
-    fn size_in_bytes(&self) -> usize {
-        ark_ff::to_bytes![G::zero()].unwrap().len() / 2
-    }
 }
 
 impl<G: AffineCurve> ToBytes for Commitment<G> {
@@ -216,11 +212,7 @@ pub struct Proof<G: AffineCurve> {
     pub rand: Option<G::ScalarField>,
 }
 
-impl<G: AffineCurve> PCProof for Proof<G> {
-    fn size_in_bytes(&self) -> usize {
-        ark_ff::to_bytes![self].unwrap().len()
-    }
-}
+impl<G: AffineCurve> PCProof for Proof<G> {}
 
 impl<G: AffineCurve> ToBytes for Proof<G> {
     #[inline]

--- a/src/kzg10/data_structures.rs
+++ b/src/kzg10/data_structures.rs
@@ -440,10 +440,6 @@ impl<E: PairingEngine> PCCommitment for Commitment<E> {
     fn has_degree_bound(&self) -> bool {
         false
     }
-
-    fn size_in_bytes(&self) -> usize {
-        ark_ff::to_bytes![E::G1Affine::zero()].unwrap().len() / 2
-    }
 }
 
 impl<E: PairingEngine> ToConstraintField<<E::Fq as Field>::BasePrimeField> for Commitment<E>
@@ -597,16 +593,7 @@ pub struct Proof<E: PairingEngine> {
     pub random_v: Option<E::Fr>,
 }
 
-impl<E: PairingEngine> PCProof for Proof<E> {
-    fn size_in_bytes(&self) -> usize {
-        let hiding_size = if self.random_v.is_some() {
-            ark_ff::to_bytes![E::Fr::zero()].unwrap().len()
-        } else {
-            0
-        };
-        ark_ff::to_bytes![E::G1Affine::zero()].unwrap().len() / 2 + hiding_size
-    }
-}
+impl<E: PairingEngine> PCProof for Proof<E> {}
 
 impl<E: PairingEngine> ToBytes for Proof<E> {
     #[inline]

--- a/src/marlin/marlin_pc/data_structures.rs
+++ b/src/marlin/marlin_pc/data_structures.rs
@@ -290,10 +290,6 @@ impl<E: PairingEngine> PCCommitment for Commitment<E> {
     fn has_degree_bound(&self) -> bool {
         self.shifted_comm.is_some()
     }
-
-    fn size_in_bytes(&self) -> usize {
-        self.comm.size_in_bytes() + self.shifted_comm.as_ref().map_or(0, |c| c.size_in_bytes())
-    }
 }
 
 /// Prepared commitment to a polynomial that optionally enforces a degree bound.


### PR DESCRIPTION
Reduce redundancy of methods and implementations by deprecating the methods
PCProof::size_in_bytes and PCCommit::size_in_bytes.
One would expect that the size in bytes is exactly the size coming off from
serialization, make it happen!

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
