### PR TITLE
Fix `msm` usage after `ark-ec` breaking change

### DIFF
--- a/src/ipa_pc/mod.rs
+++ b/src/ipa_pc/mod.rs
@@ -3,7 +3,7 @@ use crate::{BatchLCProof, Error, Evaluations, QuerySet, UVPolynomial};
 use crate::{LabeledCommitment, LabeledPolynomial, LinearCombination};
 use crate::{PCCommitterKey, PCRandomness, PCUniversalParams, PolynomialCommitment};
 
-use ark_ec::{msm::VariableBase, AffineCurve, ProjectiveCurve};
+use ark_ec::{msm::VariableBaseMSM, AffineCurve, ProjectiveCurve};
 use ark_ff::{to_bytes, Field, One, PrimeField, UniformRand, Zero};
 use ark_std::rand::RngCore;
 use ark_std::{convert::TryInto, format, marker::PhantomData, vec};
@@ -46,6 +46,7 @@ pub struct InnerProductArgPC<
 impl<G, D, P, S> InnerProductArgPC<G, D, P, S>
 where
     G: AffineCurve,
+    G::Projective: VariableBaseMSM<MSMBase = G, Scalar = G::ScalarField>,
     D: Digest,
     P: UVPolynomial<G::ScalarField>,
     S: CryptographicSponge,
@@ -65,7 +66,7 @@ where
             .map(|s| s.into_bigint())
             .collect::<Vec<_>>();
 
-        let mut comm = VariableBase::msm(comm_key, &scalars_bigint);
+        let mut comm = <G::Projective as VariableBaseMSM>::msm_bigint(comm_key, &scalars_bigint);
 
         if randomizer.is_some() {
             assert!(hiding_generator.is_some());
@@ -315,6 +316,7 @@ where
 impl<G, D, P, S> PolynomialCommitment<G::ScalarField, P, S> for InnerProductArgPC<G, D, P, S>
 where
     G: AffineCurve,
+    G::Projective: VariableBaseMSM<MSMBase = G, Scalar = G::ScalarField>,
     D: Digest,
     P: UVPolynomial<G::ScalarField, Point = G::ScalarField>,
     S: CryptographicSponge,

--- a/src/kzg10/mod.rs
+++ b/src/kzg10/mod.rs
@@ -6,7 +6,7 @@
 //! This construction achieves extractability in the algebraic group model (AGM).
 
 use crate::{BTreeMap, Error, LabeledPolynomial, PCRandomness, ToString, Vec};
-use ark_ec::msm::{FixedBase, VariableBase};
+use ark_ec::msm::{FixedBase, VariableBaseMSM};
 use ark_ec::{group::Group, AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{One, PrimeField, UniformRand, Zero};
 use ark_poly::UVPolynomial;
@@ -152,8 +152,10 @@ where
             skip_leading_zeros_and_convert_to_bigints(polynomial);
 
         let msm_time = start_timer!(|| "MSM to compute commitment to plaintext poly");
-        let mut commitment =
-            VariableBase::msm(&powers.powers_of_g[num_leading_zeros..], &plain_coeffs);
+        let mut commitment = <E::G1Projective as VariableBaseMSM>::msm_bigint(
+            &powers.powers_of_g[num_leading_zeros..],
+            &plain_coeffs,
+        );
         end_timer!(msm_time);
 
         let mut randomness = Randomness::<E::Fr, P>::empty();
@@ -174,8 +176,11 @@ where
 
         let random_ints = convert_to_bigints(&randomness.blinding_polynomial.coeffs());
         let msm_time = start_timer!(|| "MSM to compute commitment to random poly");
-        let random_commitment =
-            VariableBase::msm(&powers.powers_of_gamma_g, random_ints.as_slice()).into_affine();
+        let random_commitment = <E::G1Projective as VariableBaseMSM>::msm_bigint(
+            &powers.powers_of_gamma_g,
+            random_ints.as_slice(),
+        )
+        .into_affine();
         end_timer!(msm_time);
 
         commitment.add_assign_mixed(&random_commitment);
@@ -226,7 +231,10 @@ where
             skip_leading_zeros_and_convert_to_bigints(witness_polynomial);
 
         let witness_comm_time = start_timer!(|| "Computing commitment to witness polynomial");
-        let mut w = VariableBase::msm(&powers.powers_of_g[num_leading_zeros..], &witness_coeffs);
+        let mut w = <E::G1Projective as VariableBaseMSM>::msm_bigint(
+            &powers.powers_of_g[num_leading_zeros..],
+            &witness_coeffs,
+        );
         end_timer!(witness_comm_time);
 
         let random_v = if let Some(hiding_witness_polynomial) = hiding_witness_polynomial {
@@ -238,7 +246,10 @@ where
             let random_witness_coeffs = convert_to_bigints(&hiding_witness_polynomial.coeffs());
             let witness_comm_time =
                 start_timer!(|| "Computing commitment to random witness polynomial");
-            w += &VariableBase::msm(&powers.powers_of_gamma_g, &random_witness_coeffs);
+            w += &<E::G1Projective as VariableBaseMSM>::msm_bigint(
+                &powers.powers_of_gamma_g,
+                &random_witness_coeffs,
+            );
             end_timer!(witness_comm_time);
             Some(blinding_evaluation)
         } else {

--- a/src/multilinear_pc/mod.rs
+++ b/src/multilinear_pc/mod.rs
@@ -1,7 +1,7 @@
 use crate::multilinear_pc::data_structures::{
     Commitment, CommitterKey, Proof, UniversalParams, VerifierKey,
 };
-use ark_ec::msm::{FixedBase, VariableBase};
+use ark_ec::msm::{FixedBase, VariableBaseMSM};
 use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve};
 use ark_ff::{Field, PrimeField};
 use ark_ff::{One, Zero};
@@ -146,7 +146,11 @@ impl<E: PairingEngine> MultilinearPC<E> {
             .into_iter()
             .map(|x| x.into_bigint())
             .collect();
-        let g_product = VariableBase::msm(&ck.powers_of_g[0], scalars.as_slice()).into_affine();
+        let g_product = <E::G1Projective as VariableBaseMSM>::msm_bigint(
+            &ck.powers_of_g[0],
+            scalars.as_slice(),
+        )
+        .into_affine();
         Commitment { nv, g_product }
     }
 
@@ -178,7 +182,9 @@ impl<E: PairingEngine> MultilinearPC<E> {
                 .map(|x| q[k][x >> 1].into_bigint()) // fine
                 .collect();
 
-            let pi_h = VariableBase::msm(&ck.powers_of_h[i], &scalars).into_affine(); // no need to move outside and partition
+            let pi_h =
+                <E::G2Projective as VariableBaseMSM>::msm_bigint(&ck.powers_of_h[i], &scalars)
+                    .into_affine(); // no need to move outside and partition
             proofs.push(pi_h);
         }
 

--- a/src/streaming_kzg/mod.rs
+++ b/src/streaming_kzg/mod.rs
@@ -103,7 +103,7 @@ use ark_std::ops::{Add, Mul};
 use ark_std::borrow::Borrow;
 use ark_std::fmt;
 
-use ark_ec::{msm::VariableBase, AffineCurve, PairingEngine};
+use ark_ec::{msm::VariableBaseMSM, AffineCurve, PairingEngine};
 
 /// A Kate polynomial commitment over a bilinear group, represented as a single \\(\GG_1\\) element.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -119,7 +119,7 @@ impl<E: PairingEngine> Commitment<E> {
 #[inline]
 fn msm<E: PairingEngine>(bases: &[E::G1Affine], scalars: &[E::Fr]) -> E::G1Affine {
     let scalars = scalars.iter().map(|x| x.into_bigint()).collect::<Vec<_>>();
-    let sp = VariableBase::msm(bases, &scalars);
+    let sp = <E::G1Projective as VariableBaseMSM>::msm_bigint(bases, &scalars);
     sp.into_affine()
 }
 
@@ -184,7 +184,7 @@ impl<E: PairingEngine> VerifierKey<E> {
         proof: &EvaluationProof<E>,
     ) -> VerificationResult {
         let scalars = [(-alpha).into_bigint(), E::Fr::one().into_bigint()];
-        let ep = VariableBase::msm(&self.powers_of_g2, &scalars);
+        let ep = <E::G2Projective as VariableBaseMSM>::msm_bigint(&self.powers_of_g2, &scalars);
         let lhs =
             commitment.0.into_projective() - self.powers_of_g[0].mul(evaluation.into_bigint());
         let g2 = self.powers_of_g2[0];
@@ -213,7 +213,8 @@ impl<E: PairingEngine> VerifierKey<E> {
         // Computing the vanishing polynomial over eval_points
         let zeros = vanishing_polynomial(eval_points);
         let zeros_repr = zeros.iter().map(|x| x.into_bigint()).collect::<Vec<_>>();
-        let zeros = VariableBase::msm(&self.powers_of_g2, &zeros_repr);
+        let zeros =
+            <E::G2Projective as VariableBaseMSM>::msm_bigint(&self.powers_of_g2, &zeros_repr);
 
         // Computing the inverse for the interpolation
         let mut sca_inverse = Vec::new();
@@ -256,7 +257,7 @@ impl<E: PairingEngine> VerifierKey<E> {
         // Gathering commitments
         let comm_vec = commitments.iter().map(|x| x.0).collect::<Vec<_>>();
         let etas_repr = etas.iter().map(|e| e.into_bigint()).collect::<Vec<_>>();
-        let f_comm = VariableBase::msm(&comm_vec, &etas_repr);
+        let f_comm = <E::G1Projective as VariableBaseMSM>::msm_bigint(&comm_vec, &etas_repr);
 
         let g2 = self.powers_of_g2[0];
 

--- a/src/streaming_kzg/space.rs
+++ b/src/streaming_kzg/space.rs
@@ -7,7 +7,7 @@ use ark_std::collections::VecDeque;
 use ark_std::vec::Vec;
 
 use crate::streaming_kzg::{ceil_div, vanishing_polynomial, FoldedPolynomialTree};
-use ark_ec::msm::{ChunkedPippenger, HashMapPippenger, VariableBase};
+use ark_ec::msm::{ChunkedPippenger, HashMapPippenger, VariableBaseMSM};
 use ark_std::iterable::{Iterable, Reverse};
 
 use super::{time::CommitterKey, VerifierKey};
@@ -135,7 +135,10 @@ where
     {
         assert!(self.powers_of_g.len() >= polynomial.len());
 
-        Commitment(VariableBase::msm_chunks(&self.powers_of_g, polynomial).into_affine())
+        Commitment(
+            <E::G1Projective as VariableBaseMSM>::msm_chunks(&self.powers_of_g, polynomial)
+                .into_affine(),
+        )
     }
 
     /// The batch commitment procedures, that takes as input a committer key and the streaming coefficients of a list of polynomials, and produces the desired commitments.


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Use `<E::G{1,2}Projective as VariableBaseMSM>::msm_bigint` instead of `VariableBase::msm`.
Depends on: 
- [#435](https://github.com/arkworks-rs/algebra/pull/435) to build, 
- [#436](https://github.com/arkworks-rs/algebra/pull/436) for tests

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
