### PR TITLE
Add serialize traits to LabeledCommitment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cryptography", "commitments", "elliptic-curves", "pairing"]
 categories = ["cryptography"]
 include = ["Cargo.toml", "src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 license = "MIT/Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 ark-serialize = { version = "^0.4.0", default-features = false, features = [ "derive" ] }

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -176,7 +176,7 @@ impl<'a, F: Field, P: Polynomial<F>> LabeledPolynomial<F, P> {
 }
 
 /// A commitment along with information about its degree bound (if any).
-#[derive(Clone)]
+#[derive(Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct LabeledCommitment<C: PCCommitment> {
     label: PolynomialLabel,
     commitment: C,

--- a/src/data_structures.rs
+++ b/src/data_structures.rs
@@ -250,7 +250,7 @@ impl<'a> From<&'a str> for LCTerm {
     }
 }
 
-impl core::convert::TryInto<PolynomialLabel> for LCTerm {
+impl TryInto<PolynomialLabel> for LCTerm {
     type Error = ();
     fn try_into(self) -> Result<PolynomialLabel, ()> {
         match self {
@@ -260,7 +260,7 @@ impl core::convert::TryInto<PolynomialLabel> for LCTerm {
     }
 }
 
-impl<'a> core::convert::TryInto<&'a PolynomialLabel> for &'a LCTerm {
+impl<'a> TryInto<&'a PolynomialLabel> for &'a LCTerm {
     type Error = ();
 
     fn try_into(self) -> Result<&'a PolynomialLabel, ()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! A crate for polynomial commitment schemes.
 #![deny(unused_import_braces, unused_qualifications, trivial_casts)]
-#![deny(trivial_numeric_casts, private_in_public, variant_size_differences)]
+#![deny(trivial_numeric_casts, variant_size_differences)]
 #![deny(stable_features, unreachable_pub, non_shorthand_field_patterns)]
 #![deny(unused_attributes, unused_mut)]
 #![deny(missing_docs)]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Added CanonicalSerialize/Deserialize traits to the LabeledCommitment struct.

When poly-commit was updated to v0.4.0, the trait `ToBytes` was removed from LabeledCommit but the Serialization traits were not added.

Blocks arkworks-rs/marlin/pull/94 as LabeledCommit structs need to be absorbed by the sponge function to add entropy.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
