### PR TITLE
Fix default check combinations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! A crate for polynomial commitment schemes.
 #![deny(unused_import_braces, unused_qualifications, trivial_casts)]
-#![deny(trivial_numeric_casts, private_in_public, variant_size_differences)]
+#![deny(trivial_numeric_casts, variant_size_differences)]
 #![deny(stable_features, unreachable_pub, non_shorthand_field_patterns)]
 #![deny(unused_attributes, unused_mut)]
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,16 +354,21 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
         Self::Commitment: 'a,
     {
         let BatchLCProof { proof, evals } = proof;
-
         let lc_s = BTreeMap::from_iter(linear_combinations.into_iter().map(|lc| (lc.label(), lc)));
 
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
+        let sorted_by_poly_and_query_label: BTreeSet<_> = poly_query_set
+            .iter()
+            .map(|(poly_label, v)| ((poly_label.clone(), v.1.clone()), v.0.clone()))
+            .collect();
+
         let poly_evals = Evaluations::from_iter(
-            poly_query_set
+            sorted_by_poly_and_query_label
                 .iter()
-                .map(|(_, point)| point)
-                .cloned()
-                .zip(evals.clone().unwrap()),
+                .zip(evals.clone().unwrap())
+                .map(|(((poly_label, point), _query_label), eval)| {
+                    ((poly_label.clone(), point.clone()), eval)
+                }),
         );
 
         for &(ref lc_label, (_, ref point)) in eqn_query_set {
@@ -381,7 +386,9 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
                         LCTerm::One => F::one(),
                         LCTerm::PolyLabel(l) => *poly_evals
                             .get(&(l.clone().into(), point.clone()))
-                            .ok_or(Error::MissingEvaluation { label: l.clone() })?,
+                            .ok_or(Error::MissingEvaluation {
+                                label: format!("{}-{:?}", l.clone(), point.clone()),
+                            })?,
                     };
 
                     actual_rhs += &(*coeff * eval);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,8 +358,9 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
 
         let poly_query_set = lc_query_set_to_poly_query_set(lc_s.values().copied(), eqn_query_set);
         let sorted_by_poly_and_query_label: BTreeSet<_> = poly_query_set
-            .iter()
-            .map(|(poly_label, v)| ((poly_label.clone(), v.1.clone()), v.0.clone()))
+            .clone()
+            .into_iter()
+            .map(|(poly_label, v)| ((poly_label.clone(), v.1), v.0))
             .collect();
 
         let poly_evals = Evaluations::from_iter(
@@ -367,7 +368,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
                 .iter()
                 .zip(evals.clone().unwrap())
                 .map(|(((poly_label, point), _query_label), eval)| {
-                    ((poly_label.clone(), point.clone()), eval)
+                    ((poly_label, point), eval)
                 }),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
 
         let poly_evals = Evaluations::from_iter(
             sorted_by_poly_and_query_label
-                .iter()
+                .into_iter()
                 .zip(evals.clone().unwrap())
                 .map(|(((poly_label, point), _query_label), eval)| {
                     ((poly_label, point), eval)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,9 +367,7 @@ pub trait PolynomialCommitment<F: PrimeField, P: Polynomial<F>, S: Cryptographic
             sorted_by_poly_and_query_label
                 .into_iter()
                 .zip(evals.clone().unwrap())
-                .map(|(((poly_label, point), _query_label), eval)| {
-                    ((poly_label, point), eval)
-                }),
+                .map(|(((poly_label, point), _query_label), eval)| ((poly_label, point), eval)),
         );
 
         for &(ref lc_label, (_, ref point)) in eqn_query_set {

--- a/src/marlin/marlin_pc/mod.rs
+++ b/src/marlin/marlin_pc/mod.rs
@@ -1,7 +1,7 @@
 use crate::{kzg10, marlin::Marlin, PCCommitterKey, CHALLENGE_SIZE};
 use crate::{BTreeMap, BTreeSet, ToString, Vec};
-use crate::{BatchLCProof, Error, Evaluations, QuerySet};
-use crate::{LabeledCommitment, LabeledPolynomial, LinearCombination};
+use crate::{Error, Evaluations, QuerySet};
+use crate::{LabeledCommitment, LabeledPolynomial};
 use crate::{PCRandomness, PCUniversalParams, PolynomialCommitment};
 use ark_ec::pairing::Pairing;
 use ark_ec::AffineRepr;
@@ -401,60 +401,6 @@ where
         )?;
         end_timer!(proof_time);
         Ok(result)
-    }
-
-    fn open_combinations<'a>(
-        ck: &Self::CommitterKey,
-        lc_s: impl IntoIterator<Item = &'a LinearCombination<E::ScalarField>>,
-        polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<E::ScalarField, P>>,
-        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
-        query_set: &QuerySet<P::Point>,
-        opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
-        rands: impl IntoIterator<Item = &'a Self::Randomness>,
-        rng: Option<&mut dyn RngCore>,
-    ) -> Result<BatchLCProof<E::ScalarField, Self::BatchProof>, Self::Error>
-    where
-        P: 'a,
-        Self::Randomness: 'a,
-        Self::Commitment: 'a,
-    {
-        Marlin::<E, S, P, Self>::open_combinations(
-            ck,
-            lc_s,
-            polynomials,
-            commitments,
-            query_set,
-            opening_challenges,
-            rands,
-            rng,
-        )
-    }
-
-    /// Checks that `values` are the true evaluations at `query_set` of the polynomials
-    /// committed in `labeled_commitments`.
-    fn check_combinations<'a, R: RngCore>(
-        vk: &Self::VerifierKey,
-        lc_s: impl IntoIterator<Item = &'a LinearCombination<E::ScalarField>>,
-        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
-        query_set: &QuerySet<P::Point>,
-        evaluations: &Evaluations<E::ScalarField, P::Point>,
-        proof: &BatchLCProof<E::ScalarField, Self::BatchProof>,
-        opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
-        rng: &mut R,
-    ) -> Result<bool, Self::Error>
-    where
-        Self::Commitment: 'a,
-    {
-        Marlin::<E, S, P, Self>::check_combinations(
-            vk,
-            lc_s,
-            commitments,
-            query_set,
-            evaluations,
-            proof,
-            opening_challenges,
-            rng,
-        )
     }
 
     /// On input a list of labeled polynomials and a query set, `open` outputs a proof of evaluation

--- a/src/marlin/marlin_pc/mod.rs
+++ b/src/marlin/marlin_pc/mod.rs
@@ -1,7 +1,7 @@
 use crate::{kzg10, marlin::Marlin, PCCommitterKey, CHALLENGE_SIZE};
 use crate::{BTreeMap, BTreeSet, ToString, Vec};
-use crate::{Error, Evaluations, QuerySet};
-use crate::{LabeledCommitment, LabeledPolynomial};
+use crate::{BatchLCProof, Error, Evaluations, QuerySet};
+use crate::{LabeledCommitment, LabeledPolynomial, LinearCombination};
 use crate::{PCRandomness, PCUniversalParams, PolynomialCommitment};
 use ark_ec::pairing::Pairing;
 use ark_ec::AffineRepr;
@@ -401,6 +401,60 @@ where
         )?;
         end_timer!(proof_time);
         Ok(result)
+    }
+
+    fn open_combinations<'a>(
+        ck: &Self::CommitterKey,
+        lc_s: impl IntoIterator<Item = &'a LinearCombination<E::ScalarField>>,
+        polynomials: impl IntoIterator<Item = &'a LabeledPolynomial<E::ScalarField, P>>,
+        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
+        query_set: &QuerySet<P::Point>,
+        opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
+        rands: impl IntoIterator<Item = &'a Self::Randomness>,
+        rng: Option<&mut dyn RngCore>,
+    ) -> Result<BatchLCProof<E::ScalarField, Self::BatchProof>, Self::Error>
+    where
+        P: 'a,
+        Self::Randomness: 'a,
+        Self::Commitment: 'a,
+    {
+        Marlin::<E, S, P, Self>::open_combinations(
+            ck,
+            lc_s,
+            polynomials,
+            commitments,
+            query_set,
+            opening_challenges,
+            rands,
+            rng,
+        )
+    }
+
+    /// Checks that `values` are the true evaluations at `query_set` of the polynomials
+    /// committed in `labeled_commitments`.
+    fn check_combinations<'a, R: RngCore>(
+        vk: &Self::VerifierKey,
+        lc_s: impl IntoIterator<Item = &'a LinearCombination<E::ScalarField>>,
+        commitments: impl IntoIterator<Item = &'a LabeledCommitment<Self::Commitment>>,
+        query_set: &QuerySet<P::Point>,
+        evaluations: &Evaluations<E::ScalarField, P::Point>,
+        proof: &BatchLCProof<E::ScalarField, Self::BatchProof>,
+        opening_challenges: &mut ChallengeGenerator<E::ScalarField, S>,
+        rng: &mut R,
+    ) -> Result<bool, Self::Error>
+    where
+        Self::Commitment: 'a,
+    {
+        Marlin::<E, S, P, Self>::check_combinations(
+            vk,
+            lc_s,
+            commitments,
+            query_set,
+            evaluations,
+            proof,
+            opening_challenges,
+            rng,
+        )
     }
 
     /// On input a list of labeled polynomials and a query set, `open` outputs a proof of evaluation


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The trait-default implementation of `check_combinations` was incorrect. This was not detected because all of the implemented schemes have a custom implementation of this method. We are going to use the default method in Ligero though.

Description of the bug(s):
1. The key in `poly_evals: BTreeMap` was of type `(query_label, point)`, whereas the first element in the key tuple should have been a poly_label. This was causing map access [here](https://github.com/arkworks-rs/poly-commit/blob/d1c270e0d2eb32cdfbe986b268954d3ad0b1c4cc/src/lib.rs#L383) to fail with `MissingEvaluation`.
2. 
- `poly_query_set` was keyed only with `poly_label`, but held multiple query values with the same `poly_label`. Iterating over its keys was be done in an arbitrary order. 
- The array we zip it with, `evals`, is returned calling `values()` on `BTreeMap`, the values are returned sorted by key of type `(poly_label, point)`. 
- So the two constructed arrays were potentially in non-matching orders. To address this, we map the iterated poly labels as (`poly_label, point`), and collect first, so before it gets combined with a sorted vector of **evaluations**, it will itself get sorted on the correct key `(poly_label, point)`.
(2 might seem obvious in retrospect)

As mentioned, this is impossible to validate against the current codebase where all PCS have a custom implementation. To showcase the bug, I've sandwiched the actual fix in between 2 commits, where I first remove the custom impl from `marlin_pc` and later add it back after the fix. To verify the fix, you can check out 57ac1abc265928c58e1624a82b89c1bf490d724d, and run `cargo test marlin::marlin_pc::tests::full_end_to_end_equation_test` -> should fail.
Then checkout the fix commit dcffaecc6b621174db3048811183b3960bd12f0d, run the same command, and verify the tests pass now.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
