### PR TITLE
Rename nonnative to emulated, as in `r1cs-std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ debug = true
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-crypto-primitives = { git = "https://github.com/autquis/crypto-primitives" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "add-convert-traits-to-prelude" }
 
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ debug = true
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-crypto-primitives = { git = "https://github.com/autquis/crypto-primitives" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "add-convert-traits-to-prelude" }
+ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
 
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }

--- a/poly-commit/src/constraints.rs
+++ b/poly-commit/src/constraints.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_crypto_primitives::sponge::CryptographicSponge;
 use ark_ff::PrimeField;
 use ark_poly::Polynomial;
-use ark_r1cs_std::fields::nonnative::NonNativeFieldVar;
+use ark_r1cs_std::fields::emulated_fp::EmulatedFpVar;
 use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, Result as R1CSResult, SynthesisError};
 use ark_std::{borrow::Borrow, cmp::Eq, cmp::PartialEq, hash::Hash, marker::Sized};
@@ -24,8 +24,8 @@ pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeFiel
     One,
     /// Coefficient -1.
     MinusOne,
-    /// Other coefficient, represented as a nonnative field element.
-    Var(NonNativeFieldVar<TargetField, BaseField>),
+    /// Other coefficient, represented as a "emulated" field element.
+    Var(EmulatedFpVar<TargetField, BaseField>),
 }
 
 /// An allocated version of `LinearCombination`.
@@ -60,7 +60,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
                 let (f, lc_term) = term;
 
                 let fg =
-                    NonNativeFieldVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
+                EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
                         .unwrap();
 
                 (LinearCombinationCoeffVar::Var(fg), lc_term.clone())
@@ -79,12 +79,12 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
 pub struct PCCheckRandomDataVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Opening challenges.
     /// The prover and the verifier MUST use the same opening challenges.
-    pub opening_challenges: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    pub opening_challenges: Vec<EmulatedFpVar<TargetField, BaseField>>,
     /// Bit representations of the opening challenges.
     pub opening_challenges_bits: Vec<Vec<Boolean<BaseField>>>,
     /// Batching random numbers.
     /// The verifier can choose these numbers freely, as long as they are random.
-    pub batching_rands: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    pub batching_rands: Vec<EmulatedFpVar<TargetField, BaseField>>,
     /// Bit representations of the batching random numbers.
     pub batching_rands_bits: Vec<Vec<Boolean<BaseField>>>,
 }
@@ -172,7 +172,7 @@ pub struct LabeledPointVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// MUST be a unique identifier in a query set.
     pub name: String,
     /// The point value.
-    pub value: NonNativeFieldVar<TargetField, BaseField>,
+    pub value: EmulatedFpVar<TargetField, BaseField>,
 }
 
 /// An allocated version of `QuerySet`.
@@ -184,7 +184,7 @@ pub struct QuerySetVar<TargetField: PrimeField, BaseField: PrimeField>(
 /// An allocated version of `Evaluations`.
 #[derive(Clone)]
 pub struct EvaluationsVar<TargetField: PrimeField, BaseField: PrimeField>(
-    pub HashMap<LabeledPointVar<TargetField, BaseField>, NonNativeFieldVar<TargetField, BaseField>>,
+    pub HashMap<LabeledPointVar<TargetField, BaseField>, EmulatedFpVar<TargetField, BaseField>>,
 );
 
 impl<TargetField: PrimeField, BaseField: PrimeField> EvaluationsVar<TargetField, BaseField> {
@@ -192,8 +192,8 @@ impl<TargetField: PrimeField, BaseField: PrimeField> EvaluationsVar<TargetField,
     pub fn get_lc_eval(
         &self,
         lc_string: &str,
-        point: &NonNativeFieldVar<TargetField, BaseField>,
-    ) -> Result<NonNativeFieldVar<TargetField, BaseField>, SynthesisError> {
+        point: &EmulatedFpVar<TargetField, BaseField>,
+    ) -> Result<EmulatedFpVar<TargetField, BaseField>, SynthesisError> {
         let key = LabeledPointVar::<TargetField, BaseField> {
             name: String::from(lc_string),
             value: point.clone(),

--- a/poly-commit/src/constraints.rs
+++ b/poly-commit/src/constraints.rs
@@ -60,7 +60,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
                 let (f, lc_term) = term;
 
                 let fg =
-                EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
+                    EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
                         .unwrap();
 
                 (LinearCombinationCoeffVar::Var(fg), lc_term.clone())

--- a/poly-commit/src/streaming_kzg/data_structures.rs
+++ b/poly-commit/src/streaming_kzg/data_structures.rs
@@ -140,7 +140,7 @@ where
 
 /// Stream implementation of foleded polynomial.
 #[derive(Clone, Copy)]
-pub struct FoldedPolynomialStream<'a, F, S>(FoldedPolynomialTree<'a, F, S>, usize);
+pub struct FoldedPolynomialStream<'a, F, S>(FoldedPolynomialTree<'a, F, S>);
 /// Iterator implementation of foleded polynomial.
 pub struct FoldedPolynomialStreamIter<'a, F, I> {
     challenges: &'a [F],
@@ -157,8 +157,7 @@ where
     /// Initialize a new folded polynomial stream.
     pub fn new(coefficients: &'a S, challenges: &'a [F]) -> Self {
         let tree = FoldedPolynomialTree::new(coefficients, challenges);
-        let len = challenges.len();
-        Self(tree, len)
+        Self(tree)
     }
 }
 
@@ -240,7 +239,7 @@ fn test_folded_polynomial() {
     let challenges = vec![F::one(), two];
     let coefficients_stream = coefficients.as_slice();
     let foldstream = FoldedPolynomialTree::new(&coefficients_stream, challenges.as_slice());
-    let fold_stream = FoldedPolynomialStream(foldstream, 2);
+    let fold_stream = FoldedPolynomialStream(foldstream);
     assert_eq!(fold_stream.len(), 1);
     assert_eq!(
         fold_stream.iter().next(),
@@ -252,7 +251,7 @@ fn test_folded_polynomial() {
     let challenges = vec![F::one(); 4];
     let coefficients_stream = coefficients.as_slice();
     let foldstream = FoldedPolynomialTree::new(&coefficients_stream, challenges.as_slice());
-    let fold_stream = FoldedPolynomialStream(foldstream, 4).iter();
+    let fold_stream = FoldedPolynomialStream(foldstream).iter();
     assert_eq!(fold_stream.last(), Some(coefficients.iter().sum()));
 }
 


### PR DESCRIPTION
Just a refactor according to the last changes in `r1cs-std`

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
