### PR TITLE
Rename enum items in `ChallengeGenerator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ debug = true
 ark-ff = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-ec = { git = "https://github.com/arkworks-rs/algebra/" }
 ark-serialize = { git = "https://github.com/arkworks-rs/algebra/" }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives" }
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/" }
+ark-crypto-primitives = { git = "https://github.com/autquis/crypto-primitives" }
+ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", branch = "add-convert-traits-to-prelude" }
 
 ark-bls12-377 = { git = "https://github.com/arkworks-rs/curves/" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/" }

--- a/bench-templates/src/lib.rs
+++ b/bench-templates/src/lib.rs
@@ -123,7 +123,7 @@ where
         [&labeled_poly],
         &coms,
         &point,
-        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &mut ChallengeGenerator::new_correlated(&mut test_sponge()),
         &randomness,
         Some(rng),
     )
@@ -156,7 +156,7 @@ where
         [&labeled_poly],
         &coms,
         &point,
-        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &mut ChallengeGenerator::new_correlated(&mut test_sponge()),
         &randomness,
         Some(rng),
     )
@@ -193,7 +193,7 @@ where
         [&labeled_poly],
         &coms,
         &point,
-        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &mut ChallengeGenerator::new_correlated(&mut test_sponge()),
         &randomness,
         Some(rng),
     )
@@ -206,7 +206,7 @@ where
         &point,
         [claimed_eval],
         &proof,
-        &mut ChallengeGenerator::new_univariate(&mut test_sponge()),
+        &mut ChallengeGenerator::new_correlated(&mut test_sponge()),
         None,
     )
     .unwrap();

--- a/poly-commit/src/challenge.rs
+++ b/poly-commit/src/challenge.rs
@@ -1,45 +1,45 @@
 use ark_crypto_primitives::sponge::{CryptographicSponge, FieldElementSize};
 use ark_ff::PrimeField;
 
-/// `ChallengeGenerator` generates opening challenges using multivariate or univariate strategy.
-/// For multivariate strategy, each challenge is freshly squeezed from a sponge.
-/// For univariate strategy, each challenge is a power of one squeezed element from sponge.
+/// `ChallengeGenerator` generates opening challenges using independent or correlated strategy.
+/// For independent strategy, each challenge is freshly squeezed from a sponge.
+/// For correlated strategy, each challenge is a power of one squeezed element from sponge.
 ///
 /// Note that mutable reference cannot be cloned.
 #[derive(Clone)]
 pub enum ChallengeGenerator<F: PrimeField, S: CryptographicSponge> {
     /// Each challenge is freshly squeezed from a sponge.
-    Multivariate(S),
+    Independent(S),
     /// Each challenge is a power of one squeezed element from sponge.
     ///
-    /// `Univariate(generator, next_element)`
-    Univariate(F, F),
+    /// `Correlated(generator, next_element)`
+    Correlated(F, F),
 }
 
 impl<F: PrimeField, S: CryptographicSponge> ChallengeGenerator<F, S> {
-    /// Returns a challenge generator with multivariate strategy. Each challenge is freshly squeezed
+    /// Returns a challenge generator with independent strategy. Each challenge is freshly squeezed
     /// from a sponge.
-    pub fn new_multivariate(sponge: S) -> Self {
-        Self::Multivariate(sponge)
+    pub fn new_independent(sponge: S) -> Self {
+        Self::Independent(sponge)
     }
 
-    /// Returns a challenge generator with univariate strategy. Each challenge is a power of one
+    /// Returns a challenge generator with correlated strategy. Each challenge is a power of one
     /// squeezed element from sponge.
-    pub fn new_univariate(sponge: &mut S) -> Self {
+    pub fn new_correlated(sponge: &mut S) -> Self {
         let gen = sponge.squeeze_field_elements(1)[0];
-        Self::Univariate(gen, gen)
+        Self::Correlated(gen, gen)
     }
 
     /// Returns a challenge of size `size`.
-    /// * If `self == Self::Multivariate(...)`, then this squeezes out a challenge of size `size`.
-    /// * If `self == Self::Univariate(...)`, then this ignores the `size` argument and simply squeezes out
+    /// * If `self == Self::Independent(...)`, then this squeezes out a challenge of size `size`.
+    /// * If `self == Self::Correlated(...)`, then this ignores the `size` argument and simply squeezes out
     /// the next field element.
     pub fn try_next_challenge_of_size(&mut self, size: FieldElementSize) -> F {
         match self {
-            // multivariate (full)
-            Self::Multivariate(sponge) => sponge.squeeze_field_elements_with_sizes(&[size])[0],
-            // univariate
-            Self::Univariate(gen, next) => {
+            // independent (full)
+            Self::Independent(sponge) => sponge.squeeze_field_elements_with_sizes(&[size])[0],
+            // correlated
+            Self::Correlated(gen, next) => {
                 let result = next.clone();
                 *next *= *gen;
                 result
@@ -51,10 +51,10 @@ impl<F: PrimeField, S: CryptographicSponge> ChallengeGenerator<F, S> {
         self.try_next_challenge_of_size(FieldElementSize::Full)
     }
 
-    /// Returns the sponge state if `self` is multivariate. Returns `None` otherwise.
+    /// Returns the sponge state if `self` is independent. Returns `None` otherwise.
     pub fn into_sponge(self) -> Option<S> {
         match self {
-            Self::Multivariate(s) => Some(s),
+            Self::Independent(s) => Some(s),
             _ => None,
         }
     }

--- a/poly-commit/src/constraints.rs
+++ b/poly-commit/src/constraints.rs
@@ -5,7 +5,7 @@ use crate::{
 use ark_crypto_primitives::sponge::CryptographicSponge;
 use ark_ff::PrimeField;
 use ark_poly::Polynomial;
-use ark_r1cs_std::fields::nonnative::NonNativeFieldVar;
+use ark_r1cs_std::fields::emulated_fp::EmulatedFpVar;
 use ark_r1cs_std::{fields::fp::FpVar, prelude::*};
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace, Result as R1CSResult, SynthesisError};
 use ark_std::{borrow::Borrow, cmp::Eq, cmp::PartialEq, hash::Hash, marker::Sized};
@@ -24,8 +24,8 @@ pub enum LinearCombinationCoeffVar<TargetField: PrimeField, BaseField: PrimeFiel
     One,
     /// Coefficient -1.
     MinusOne,
-    /// Other coefficient, represented as a nonnative field element.
-    Var(NonNativeFieldVar<TargetField, BaseField>),
+    /// Other coefficient, represented as a "emulated" field element.
+    Var(EmulatedFpVar<TargetField, BaseField>),
 }
 
 /// An allocated version of `LinearCombination`.
@@ -60,7 +60,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
                 let (f, lc_term) = term;
 
                 let fg =
-                    NonNativeFieldVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
+                EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
                         .unwrap();
 
                 (LinearCombinationCoeffVar::Var(fg), lc_term.clone())
@@ -79,12 +79,12 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
 pub struct PCCheckRandomDataVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// Opening challenges.
     /// The prover and the verifier MUST use the same opening challenges.
-    pub opening_challenges: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    pub opening_challenges: Vec<EmulatedFpVar<TargetField, BaseField>>,
     /// Bit representations of the opening challenges.
     pub opening_challenges_bits: Vec<Vec<Boolean<BaseField>>>,
     /// Batching random numbers.
     /// The verifier can choose these numbers freely, as long as they are random.
-    pub batching_rands: Vec<NonNativeFieldVar<TargetField, BaseField>>,
+    pub batching_rands: Vec<EmulatedFpVar<TargetField, BaseField>>,
     /// Bit representations of the batching random numbers.
     pub batching_rands_bits: Vec<Vec<Boolean<BaseField>>>,
 }
@@ -172,7 +172,7 @@ pub struct LabeledPointVar<TargetField: PrimeField, BaseField: PrimeField> {
     /// MUST be a unique identifier in a query set.
     pub name: String,
     /// The point value.
-    pub value: NonNativeFieldVar<TargetField, BaseField>,
+    pub value: EmulatedFpVar<TargetField, BaseField>,
 }
 
 /// An allocated version of `QuerySet`.
@@ -184,7 +184,7 @@ pub struct QuerySetVar<TargetField: PrimeField, BaseField: PrimeField>(
 /// An allocated version of `Evaluations`.
 #[derive(Clone)]
 pub struct EvaluationsVar<TargetField: PrimeField, BaseField: PrimeField>(
-    pub HashMap<LabeledPointVar<TargetField, BaseField>, NonNativeFieldVar<TargetField, BaseField>>,
+    pub HashMap<LabeledPointVar<TargetField, BaseField>, EmulatedFpVar<TargetField, BaseField>>,
 );
 
 impl<TargetField: PrimeField, BaseField: PrimeField> EvaluationsVar<TargetField, BaseField> {
@@ -192,8 +192,8 @@ impl<TargetField: PrimeField, BaseField: PrimeField> EvaluationsVar<TargetField,
     pub fn get_lc_eval(
         &self,
         lc_string: &str,
-        point: &NonNativeFieldVar<TargetField, BaseField>,
-    ) -> Result<NonNativeFieldVar<TargetField, BaseField>, SynthesisError> {
+        point: &EmulatedFpVar<TargetField, BaseField>,
+    ) -> Result<EmulatedFpVar<TargetField, BaseField>, SynthesisError> {
         let key = LabeledPointVar::<TargetField, BaseField> {
             name: String::from(lc_string),
             value: point.clone(),

--- a/poly-commit/src/constraints.rs
+++ b/poly-commit/src/constraints.rs
@@ -60,7 +60,7 @@ impl<TargetField: PrimeField, BaseField: PrimeField>
                 let (f, lc_term) = term;
 
                 let fg =
-                EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
+                    EmulatedFpVar::new_variable(ark_relations::ns!(cs, "term"), || Ok(f), mode)
                         .unwrap();
 
                 (LinearCombinationCoeffVar::Var(fg), lc_term.clone())

--- a/poly-commit/src/lib.rs
+++ b/poly-commit/src/lib.rs
@@ -666,8 +666,8 @@ pub mod tests {
         S: CryptographicSponge,
     {
         let challenge_generators = vec![
-            ChallengeGenerator::new_multivariate(sponge()),
-            ChallengeGenerator::new_univariate(&mut sponge()),
+            ChallengeGenerator::new_independent(sponge()),
+            ChallengeGenerator::new_correlated(&mut sponge()),
         ];
 
         for challenge_gen in challenge_generators {
@@ -774,8 +774,8 @@ pub mod tests {
         } = info;
 
         let challenge_gens = vec![
-            ChallengeGenerator::new_multivariate(sponge()),
-            ChallengeGenerator::new_univariate(&mut sponge()),
+            ChallengeGenerator::new_independent(sponge()),
+            ChallengeGenerator::new_correlated(&mut sponge()),
         ];
 
         for challenge_gen in challenge_gens {
@@ -919,8 +919,8 @@ pub mod tests {
         } = info;
 
         let challenge_gens = vec![
-            ChallengeGenerator::new_multivariate(sponge()),
-            ChallengeGenerator::new_univariate(&mut sponge()),
+            ChallengeGenerator::new_independent(sponge()),
+            ChallengeGenerator::new_correlated(&mut sponge()),
         ];
 
         for challenge_gen in challenge_gens {


### PR DESCRIPTION
## Description

The names of the enum items in `ChallengeGenerator` are a bit confusing. This PR is a suggestion for renaming them. I think `Independent` is a more descriptive name than `Multivariate`. Ditto for `Correlated`.

This PR is on top of #137 

Pointed out by @mmagician 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (master)
- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [ ] Wrote unit tests
- [ ] Updated relevant documentation in the code
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
