### PR TITLE
fix: typos in documentation files

### DIFF
--- a/poly-commit/README.md
+++ b/poly-commit/README.md
@@ -102,7 +102,7 @@ SonicPC additionally computes some G2 elements for shift powers: `(1/\beta)^i H`
 
 When there is no degree bound, both are the same.
 
-When there is a degree bound, MarlinPC is more expensive: it needs an additional commitment to commit to the shifted poynomial. 
+When there is a degree bound, MarlinPC is more expensive: it needs an additional commitment to commit to the shifted polynomial. 
 
 #### Open: 
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

Description correction:
Corrected `poynomial` to `polynomial`

Please review the changes and let me know if any additional changes are needed.

