### PR TITLE
Typo correction README.md

### DIFF
--- a/poly-commit/README.md
+++ b/poly-commit/README.md
@@ -102,7 +102,7 @@ SonicPC additionally computes some G2 elements for shift powers: `(1/\beta)^i H`
 
 When there is no degree bound, both are the same.
 
-When there is a degree bound, MarlinPC is more expensive: it needs an additional commitment to commit to the shifted poynomial. 
+When there is a degree bound, MarlinPC is more expensive: it needs an additional commitment to commit to the shifted polynomial. 
 
 #### Open: 
 


### PR DESCRIPTION
This pull request corrects a typo in the `README.md` file. Specifically, the word "poynomial" has been corrected to "polynomial" in the section comparing MarlinPC and SonicPC.

## Checklist:

- [x] Targeted PR against correct branch (e.g., master)
- [ ] Linked to a GitHub issue with discussion and accepted design OR added an explanation of this work.
- [ ] Wrote unit tests (n/a - typo fix only).
- [x] Updated relevant documentation in the code (the `README.md` file).
- [ ] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md` (n/a - typo fix only).
- [x] Re-reviewed `Files changed` in the GitHub PR explorer.