### PR TITLE
Summary of Changes

### DIFF
--- a/poly-commit/src/hyrax/data_structures.rs
+++ b/poly-commit/src/hyrax/data_structures.rs
@@ -7,7 +7,7 @@ use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{rand::RngCore, vec::Vec};
 
-/// `UniversalParams` amounts to a Pederson commitment key of sufficient length
+/// `UniversalParams` amounts to a Pedersen commitment key of sufficient length
 #[derive(Derivative, CanonicalSerialize, CanonicalDeserialize)]
 #[derivative(Default(bound = ""), Clone(bound = ""), Debug(bound = ""))]
 pub struct HyraxUniversalParams<G: AffineRepr> {
@@ -92,7 +92,7 @@ where
 }
 
 /// A vector of scalars, each of which multiplies the distinguished group
-/// element in the Pederson commitment key for a different commitment
+/// element in the Pedersen commitment key for a different commitment
 impl<F: PrimeField> PCCommitmentState for HyraxCommitmentState<F> {
     type Randomness = HyraxRandomness<F>;
     fn empty() -> Self {

--- a/poly-commit/src/hyrax/mod.rs
+++ b/poly-commit/src/hyrax/mod.rs
@@ -25,7 +25,7 @@ mod utils;
 /// Note that the latter should never be used in production environments.
 pub const PROTOCOL_NAME: &'static [u8] = b"Hyrax protocol";
 
-/// Hyrax polynomial committment scheme:
+/// Hyrax polynomial commitment scheme:
 /// A polynomial commitment scheme based on the hardness of the
 /// discrete logarithm problem in prime-order groups. This is a
 /// Fiat-Shamired version of the PCS described in the Hyrax paper


### PR DESCRIPTION

This pull request corrects the spelling of "Pederson" to "Pedersen" in the documentation comments. The correct spelling is important as it refers to the Pedersen commitment scheme, named after the Danish cryptographer Torben Pedersen.

#### Changes Made:

1. **File:** `poly-commit/src/hyrax/data_structures.rs`
   - **Line 10:** Changed `Pederson` to `Pedersen` in the comment:
     ```rust
     /// `UniversalParams` amounts to a Pedersen commitment key of sufficient length
     ```
   - **Line 95:** Changed `Pederson` to `Pedersen` in the comment:
     ```rust
     /// element in the Pedersen commitment key for a different commitment
     ```

2. **File:** `poly-commit/src/hyrax/mod.rs`
   - **Line 28:** Changed `committment` to `commitment` in the comment:
     ```rust
     /// Hyrax polynomial commitment scheme:
     ```

### Reason for Changes

- **Correct Spelling:** The term "Pedersen" is the correct spelling for the commitment scheme, ensuring accuracy and clarity in the documentation.
- **Typographical Correction:** Corrected "committment" to "commitment" to maintain consistency and professionalism in the codebase.


